### PR TITLE
fix - openshift_Dockerfile is removed in v4.0.1

### DIFF
--- a/deployment/openshift/webapi_bc.yaml
+++ b/deployment/openshift/webapi_bc.yaml
@@ -46,7 +46,7 @@ objects:
     strategy:
       type: Docker
       dockerStrategy:
-        dockerfilePath: Openshift_Dockerfile
+        dockerfilePath: Dockerfile
     triggers:
       - type: ImageChange
         imageChange: {}


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG

# Changes
<!-- 
What are the main changes in the PR?
Openshift webapi build breaks because of reference to deleted openshift_Dockerfile. Fixed the issue by changing the reference in webapi_bc.yaml. 
Error: 
Cloning "https://github.com/AOT-Technologies/forms-flow-ai" ...
	Commit:	2534f49401fa3b5ef72e9d64bb040abcf893f6d5 (Pr 08/07 (#122))
	Author:	abhilash-aot <abhilash.kr@aot-technologies.com>
	Date:	Thu Jul 8 10:08:28 2021 +0530
error: open /tmp/build/inputs/forms-flow-api/Openshift_Dockerfile: no such file or directory



# How has the change been tested?
Manual verification of Taft openshift build.

# Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/56086163/124872550-40236e00-df7a-11eb-9120-03a25c9472d3.png)

# Build Success screenshot (Till a CICD pipeline is set up)
![image](https://user-images.githubusercontent.com/56086163/124872733-7bbe3800-df7a-11eb-93e8-6c0dbab62c15.png)

# Notes

