### PR TITLE
adding processTenant to application schema and application response

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/application.py
+++ b/forms-flow-api/src/formsflow_api/models/application.py
@@ -84,6 +84,7 @@ class Application(
                 cls.modified_by,
                 FormProcessMapper.process_key,
                 FormProcessMapper.process_name,
+                FormProcessMapper.process_tenant,
                 FormProcessMapper.form_name.label("application_name"),
             )
             .join(cls, FormProcessMapper.id == cls.form_process_mapper_id)
@@ -161,6 +162,7 @@ class Application(
             FormProcessMapper.form_name.label("application_name"),
             FormProcessMapper.process_key.label("process_key"),
             FormProcessMapper.process_name.label("process_name"),
+            FormProcessMapper.process_tenant.label("process_tenant"),
         )
         query = query.filter(*filter_conditions) if filter_conditions else query
         return query
@@ -210,6 +212,7 @@ class Application(
                 FormProcessMapper.form_name.label("application_name"),
                 FormProcessMapper.process_key.label("process_key"),
                 FormProcessMapper.process_name.label("process_name"),
+                FormProcessMapper.process_tenant.label("process_tenant"),
             )
         )
         result = cls.tenant_authorization(query=result)
@@ -314,6 +317,7 @@ class Application(
                 FormProcessMapper.form_name.label("application_name"),
                 FormProcessMapper.process_key.label("process_key"),
                 FormProcessMapper.process_name.label("process_name"),
+                FormProcessMapper.process_tenant.label("process_tenant"),
             )
         )
         query = cls.tenant_authorization(query=query)
@@ -345,6 +349,7 @@ class Application(
                 FormProcessMapper.form_name.label("application_name"),
                 FormProcessMapper.process_key.label("process_key"),
                 FormProcessMapper.process_name.label("process_name"),
+                FormProcessMapper.process_tenant.label("process_tenant"),
             )
             .one_or_none()
         )
@@ -550,6 +555,7 @@ class Application(
             FormProcessMapper.query.with_entities(
                 FormProcessMapper.process_key,
                 FormProcessMapper.process_name,
+                FormProcessMapper.process_tenant,
                 FormProcessMapper.task_variable,
                 FormProcessMapper.id.label("mapper_id"),
             )

--- a/forms-flow-api/src/formsflow_api/schemas/application.py
+++ b/forms-flow-api/src/formsflow_api/schemas/application.py
@@ -54,6 +54,7 @@ class ApplicationSchema(Schema):
     process_instance_id = fields.Str(data_key="processInstanceId")
     process_key = fields.Str(data_key="processKey")
     process_name = fields.Str(data_key="processName")
+    process_tenant = fields.Str(data_key="processTenant")
     created_by = fields.Str(data_key="createdBy")
     created = fields.Str()
     modified_by = fields.Str(data_key="modifiedBy")


### PR DESCRIPTION

# Changes
Added process_tenant to application schema and filter queries

# How has the change been tested?
 
Unit tests, Manual verification

# Notes
Adding process_tenant to the application response would be helpful for the front end to identify the tenant of a particular process. Currently, the front end needs to loop through the process with the process key to identify the tenant during the application detail view, and only form/:formid returns the process tenant which is used for view/edit component
