### PR TITLE
Download API response data in binary format

### DIFF
--- a/forms-flow-api/src/formsflow_api/resources/cmis_connector.py
+++ b/forms-flow-api/src/formsflow_api/resources/cmis_connector.py
@@ -106,7 +106,11 @@ class CMISConnectorDownloadResource(Resource):
                     "message": "No file data found"
                 }, HTTPStatus.INTERNAL_SERVER_ERROR
             result = results[0]
-            return [{"name": result.name, "data": result.getContentStream().read()}]
+            data = result.getContentStream().read()
+            binary_data = "".join(
+                format(i, "08b") for i in bytearray(data, encoding="utf-8")
+            )
+            return [{"name": result.name, "data": binary_data}]
         except AssertionError:
             return {"message": "No file data found"}, HTTPStatus.INTERNAL_SERVER_ERROR
         except BaseException as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
Change in the response of cmis download API. Response data is changed from string to binary format.
Response data in string format.

![image](https://user-images.githubusercontent.com/99173163/172840660-e1294a33-f398-4d6b-8bc5-a103878659a0.png)

Response data in binary format.

![image](https://user-images.githubusercontent.com/99173163/172841133-616a36a2-d73a-47d3-aade-841cf3882dfa.png)

# How has the change been tested?
Manual verification


