### PR TITLE
✅ Ci flake8-isort version fix

### DIFF
--- a/forms-flow-api/requirements/dev.txt
+++ b/forms-flow-api/requirements/dev.txt
@@ -5,7 +5,7 @@ flake8
 flake8-blind-except
 flake8-debugger
 flake8-docstrings
-flake8-isort
+flake8-isort==4.1.1
 flake8-polyfill
 flake8-quotes
 lovely-pytest-docker


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: 

# Changes
flake8-isort version fixed to 4.1.1

