### PR TITLE
🛂 Role API modifications

### DIFF
--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
@@ -105,7 +105,7 @@ def get_role_ids_from_user_groups(role_ids, user_role):
         raise ValueError("Inavlid arguments passed")
 
     if DESIGNER_GROUP in user_role:
-        return filter_list_by_user_role(FormioRoles.DESIGNER.name, role_ids)
+        return role_ids
     if REVIEWER_GROUP in user_role:
         return filter_list_by_user_role(FormioRoles.REVIEWER.name, role_ids)
     if CLIENT_GROUP in user_role:

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/util.py
@@ -105,7 +105,7 @@ def get_role_ids_from_user_groups(role_ids, user_role):
         raise ValueError("Inavlid arguments passed")
 
     if DESIGNER_GROUP in user_role:
-        return role_ids
+        return filter_list_by_user_role(FormioRoles.DESIGNER.name, role_ids)
     if REVIEWER_GROUP in user_role:
         return filter_list_by_user_role(FormioRoles.REVIEWER.name, role_ids)
     if CLIENT_GROUP in user_role:

--- a/forms-flow-api/src/formsflow_api/config.py
+++ b/forms-flow-api/src/formsflow_api/config.py
@@ -101,7 +101,7 @@ class _Config:  # pylint: disable=too-few-public-methods
     )
 
     # Formio JWT Secret
-    FORMIO_JWT_SECRET = os.getenv("FORMIO_JWT_SECRET", "---- change me now ---")
+    FORMIO_JWT_SECRET = os.getenv("FORMIO_JWT_SECRET", "--- change me now ---")
 
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods

--- a/forms-flow-api/src/formsflow_api/resources/formio.py
+++ b/forms-flow-api/src/formsflow_api/resources/formio.py
@@ -15,6 +15,10 @@ from formsflow_api_utils.utils import (
 )
 from formsflow_api_utils.utils.enums import FormioRoles
 from formsflow_api_utils.utils.user_context import UserContext, user_context
+from formsflow_api_utils.utils.startup import (
+    collect_role_ids,
+    collect_user_resource_ids,
+)
 
 API = Namespace("Formio", description="formio")
 
@@ -72,11 +76,19 @@ class FormioResource(Resource):
         try:
             user_role = user.roles
             role_ids = cache.get("formio_role_ids")
+            formio_user_resource_id = cache.get("user_resource_id")
+            if not role_ids:
+                collect_role_ids(current_app)
+                role_ids = cache.get("formio_role_ids")
+            if not formio_user_resource_id:
+                collect_user_resource_ids(current_app)
+                formio_user_resource_id = cache.get("user_resource_id")
+
             roles = get_role_ids_from_user_groups(role_ids, user_role)
             if roles is not None:
                 roles.append(
                     {
-                        "roleId": cache.get("user_resource_id"),
+                        "roleId": formio_user_resource_id,
                         "type": FormioRoles.RESOURCE_ID.value,
                     }
                 )

--- a/forms-flow-api/src/formsflow_api/resources/formio.py
+++ b/forms-flow-api/src/formsflow_api/resources/formio.py
@@ -23,10 +23,7 @@ from formsflow_api_utils.utils.startup import (
     collect_user_resource_ids,
 )
 from formsflow_api_utils.utils.user_context import UserContext, user_context
-from formsflow_api_utils.utils.startup import (
-    collect_role_ids,
-    collect_user_resource_ids,
-)
+
 
 API = Namespace("Formio", description="formio")
 
@@ -61,7 +58,7 @@ class FormioResource(Resource):
                 role["roleId"]
                 for role in list(
                     filter(
-                        lambda item: filter_user_based_role_ids(item),
+                        filter_user_based_role_ids,
                         response.json.get("form"),
                     )
                 )

--- a/forms-flow-api/tests/unit/api/test_formio.py
+++ b/forms-flow-api/tests/unit/api/test_formio.py
@@ -24,10 +24,7 @@ def test_formio_roles(app, client, session, jwt):
     response = client.get("/formio/roles", headers=headers)
 
     assert response.status_code == 200
-    assert response.json["form"][0]["roleId"] == 1
-    assert response.json["form"][0]["type"] == FormioRoles.CLIENT.name
-    assert response.json["form"][1]["type"] == FormioRoles.RESOURCE_ID.name
-    assert response.json["form"][1]["roleId"] == resource_id
+    assert response.json["form"] == []
     assert response.headers["x-jwt-token"]
     decoded_token = pyjwt.decode(
         response.headers["x-jwt-token"],
@@ -41,10 +38,8 @@ def test_formio_roles(app, client, session, jwt):
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
     response = client.get("/formio/roles", headers=headers)
 
-    assert response.json["form"][0]["roleId"] == 2
-    assert response.json["form"][0]["type"] == FormioRoles.REVIEWER.name
-    assert response.json["form"][1]["type"] == FormioRoles.RESOURCE_ID.name
-    assert response.json["form"][1]["roleId"] == "62cc9223b5cad9348f5880a9"
+    assert response.status_code == 200
+    assert response.json["form"] == []
 
     # Requesting from designer role
     cache.set("user_resource_id", "123456789", timeout=0)


### PR DESCRIPTION
- Formio token modified to contain only current users' role ids.
- `/role` API response will be empty for non-designers since the data is not required. (we still send the token )
- updated test cases for the same