### PR TITLE
Fixed importing workflow for second time bug

### DIFF
--- a/forms-flow-web/src/components/Modeller/index.js
+++ b/forms-flow-web/src/components/Modeller/index.js
@@ -113,6 +113,7 @@ export default React.memo(() => {
   };
 
   const handleChangeFile = (file) => {
+    setShowModeller(false);
     setIsNewDiagram(true);
     let fileData = new FileReader();
     try {


### PR DESCRIPTION
# Issue Tracking

JIRA: [FWF-1678](https://aottech.atlassian.net/browse/FWF-1678)
Issue Type: BUG

# Changes
Fixed the issue of App2/Multitenancy - Not getting workflow after choosing a workflow from local directory for the second time
User can now import a workflow from local directory a second time and the workflow will now be rendered in the canvas
Dropdown and canvas is updated with correct workflow
