### PR TITLE
Fixed the unique Id error in the properties panel from deployment

### DIFF
--- a/forms-flow-web/src/components/Modeller/Editors/BpmnEditor/index.js
+++ b/forms-flow-web/src/components/Modeller/Editors/BpmnEditor/index.js
@@ -178,7 +178,7 @@ export default React.memo(
           if (res?.data) {
             toast.success(t(SUCCESS_MSG));
             // Reload the dropdown menu
-            updateBpmProcesses(xml);
+            updateBpmProcesses(xml, res.data.deployedProcessDefinitions);
           } else {
             toast.error(t(ERROR_MSG));
           }
@@ -232,7 +232,7 @@ export default React.memo(
       return isValidated;
     };
 
-    const updateBpmProcesses = (xml) => {
+    const updateBpmProcesses = (xml, deployedProcessDefinitions) => {
       // Update drop down with all processes
       dispatch(fetchAllBpmProcesses(tenantKey));
       // Show the updated workflow as the current value in the dropdown
@@ -240,6 +240,7 @@ export default React.memo(
         label: extractDataFromDiagram(xml).name,
         value: extractDataFromDiagram(xml).processId,
         xml: xml,
+        deployedDefinitions: deployedProcessDefinitions
       };
       dispatch(setWorkflowAssociation(updatedWorkflow));
     };

--- a/forms-flow-web/src/components/Modeller/Editors/DmnEditor/index.js
+++ b/forms-flow-web/src/components/Modeller/Editors/DmnEditor/index.js
@@ -163,7 +163,7 @@ export default React.memo(
           if (res?.data) {
             toast.success(t(SUCCESS_MSG));
             // Reload the dropdown menu
-            updateBpmProcesses(xml);
+            updateDmnProcesses(xml, res.data.deployedDecisionDefinitions);
           } else {
             toast.error(t(ERROR_MSG));
           }
@@ -190,7 +190,7 @@ export default React.memo(
       }
     };
 
-    const updateBpmProcesses = (xml) => {
+    const updateDmnProcesses = (xml, deployedDecisionDefinitions) => {
       // Update drop down with all processes
       dispatch(fetchAllDmnProcesses(tenantKey));
       // Show the updated workflow as the current value in the dropdown
@@ -198,6 +198,7 @@ export default React.memo(
         label: extractDataFromDiagram(xml, true).name,
         value: extractDataFromDiagram(xml, true).processId,
         xml: xml,
+        deployedDefinitions: deployedDecisionDefinitions
       };
       dispatch(setWorkflowAssociation(updatedWorkflow));
     };

--- a/forms-flow-web/src/components/Modeller/index.js
+++ b/forms-flow-web/src/components/Modeller/index.js
@@ -58,11 +58,26 @@ export default React.memo(() => {
   }, [isBpmnModel]);
 
   const handleListChange = (item) => {
-    setIsNewDiagram(false);
-    setShowModeller(true);
-    dispatch(setWorkflowAssociation(item));
-    dispatch(setProcessDiagramXML(null));
-    showChosenFileName(item);
+
+    // Check to see if the selected process/definition is already rendered in the canvas
+    // Resolves the false 'ID must be unique' error in the properties panel
+    const object = workflow?.deployedDefinitions;
+    let found = false;
+    if (object){
+      for (const value of Object.values(object)) { 
+        if (value?.key == item.value){
+          found = true;
+        }
+      }
+    }
+
+    if (!found){
+      setIsNewDiagram(false);
+      setShowModeller(true);
+      dispatch(setWorkflowAssociation(item));
+      dispatch(setProcessDiagramXML(null));
+      showChosenFileName(item);
+    }
   };
 
   const showChosenFileName = (item) => {


### PR DESCRIPTION
# Issue Tracking

JIRA: FWF-1700
Issue Type: BUG

# Changes
The 'ID must be unique' error in the properties panel has been avoided by not allowing the user to select an item in the dropdown that has the process/decision that was just deployed.

