### PR TITLE
Refresh modeler after deployment to fix false 'unique ID' error 

### DIFF
--- a/forms-flow-web/src/components/Modeller/Editors/BpmnEditor/index.js
+++ b/forms-flow-web/src/components/Modeller/Editors/BpmnEditor/index.js
@@ -8,6 +8,7 @@ import { extractDataFromDiagram } from "../../helpers/helper";
 import { createXML } from "../../helpers/deploy";
 import { MULTITENANCY_ENABLED } from "../../../../constants/constants";
 import { deployBpmnDiagram } from "../../../../apiManager/services/bpmServices";
+import Loading from "../../../../containers/Loading";
 
 import {
   SUCCESS_MSG,
@@ -52,33 +53,38 @@ export default React.memo(
     const tenantKey = useSelector((state) => state.tenants?.tenantId);
     const [applyAllTenants, setApplyAllTenants] = useState(false);
     const [lintErrors, setLintErrors] = useState([]);
+    const [deploymentLoading, setDeploymentLoading] = useState(false);
 
     const containerRef = useCallback((node) => {
       if (node !== null) {
-        setBpmnModeller(
-          new BpmnModeler({
-            container: "#canvas",
-            propertiesPanel: {
-              parent: "#js-properties-panel",
-            },
-            linting: {
-              bpmnlint: linterConfig,
-              active: true,
-            },
-            additionalModules: [
-              BpmnPropertiesPanelModule,
-              BpmnPropertiesProviderModule,
-              CamundaPlatformPropertiesProviderModule,
-              CamundaExtensionModule,
-              lintModule,
-            ],
-            moddleExtensions: {
-              camunda: camundaModdleDescriptors,
-            },
-          })
-        );
+        initializeModeler();
       }
     }, []);
+
+    const initializeModeler = () => {
+      setBpmnModeller(
+        new BpmnModeler({
+          container: "#canvas",
+          propertiesPanel: {
+            parent: "#js-properties-panel",
+          },
+          linting: {
+            bpmnlint: linterConfig,
+            active: true,
+          },
+          additionalModules: [
+            BpmnPropertiesPanelModule,
+            BpmnPropertiesProviderModule,
+            CamundaPlatformPropertiesProviderModule,
+            CamundaExtensionModule,
+            lintModule,
+          ],
+          moddleExtensions: {
+            camunda: camundaModdleDescriptors,
+          },
+        })
+      );
+    };
 
     useEffect(() => {
       if (diagramXML) {
@@ -180,6 +186,7 @@ export default React.memo(
             toast.success(t(SUCCESS_MSG));
             // Reload the dropdown menu
             updateBpmProcesses(xml);
+            refreshModeller();
           } else {
             toast.error(t(ERROR_MSG));
           }
@@ -187,6 +194,13 @@ export default React.memo(
         .catch((error) => {
           showCamundaHTTTPErrors(error);
         });
+    };
+
+    const refreshModeller = () => {
+      bpmnModeller.destroy();
+      setDeploymentLoading(true);
+      initializeModeler();
+      setDeploymentLoading(false);
     };
 
     const showCamundaHTTTPErrors = (error) => {
@@ -289,7 +303,9 @@ export default React.memo(
               style={{
                 border: "1px solid #000000",
               }}
-            ></div>
+            >
+              {!deploymentLoading ? null : <Loading />}
+            </div>
 
             <div className="d-flex justify-content-end zoom-container">
               <div className="d-flex flex-column">

--- a/forms-flow-web/src/components/Modeller/Editors/DmnEditor/index.js
+++ b/forms-flow-web/src/components/Modeller/Editors/DmnEditor/index.js
@@ -8,6 +8,7 @@ import { extractDataFromDiagram } from "../../helpers/helper";
 import { createXML } from "../../helpers/deploy";
 import { MULTITENANCY_ENABLED } from "../../../../constants/constants";
 import { deployBpmnDiagram } from "../../../../apiManager/services/bpmServices";
+import Loading from "../../../../containers/Loading";
 
 import { SUCCESS_MSG, ERROR_MSG } from "../../constants/bpmnModellerConstants";
 
@@ -42,29 +43,34 @@ export default React.memo(
     const [dmnModeller, setBpmnModeller] = useState(null);
     const tenantKey = useSelector((state) => state.tenants?.tenantId);
     const [applyAllTenants, setApplyAllTenants] = useState(false);
+    const [deploymentLoading, setDeploymentLoading] = useState(false);
 
     const containerRef = useCallback((node) => {
       if (node !== null) {
-        setBpmnModeller(
-          new DmnJS({
-            container: "#canvas",
-            drd: {
-              propertiesPanel: {
-                parent: "#js-properties-panel",
-              },
-              additionalModules: [
-                DmnPropertiesPanelModule,
-                DmnPropertiesProviderModule,
-                CamundaPropertiesProviderModule,
-              ],
-            },
-            moddleExtensions: {
-              camunda: camundaModdleDescriptor,
-            },
-          })
-        );
+        initializeModeler();
       }
     }, []);
+
+    const initializeModeler = () => {
+      setBpmnModeller(
+        new DmnJS({
+          container: "#canvas",
+          drd: {
+            propertiesPanel: {
+              parent: "#js-properties-panel",
+            },
+            additionalModules: [
+              DmnPropertiesPanelModule,
+              DmnPropertiesProviderModule,
+              CamundaPropertiesProviderModule,
+            ],
+          },
+          moddleExtensions: {
+            camunda: camundaModdleDescriptor,
+          },
+        })
+      );
+    };
 
     useEffect(() => {
       if (diagramXML) {
@@ -164,6 +170,7 @@ export default React.memo(
             toast.success(t(SUCCESS_MSG));
             // Reload the dropdown menu
             updateBpmProcesses(xml);
+            refreshModeller();
           } else {
             toast.error(t(ERROR_MSG));
           }
@@ -171,6 +178,13 @@ export default React.memo(
         .catch((error) => {
           showCamundaHTTTPErrors(error);
         });
+    };
+
+    const refreshModeller = () => {
+      dmnModeller.destroy();
+      setDeploymentLoading(true);
+      initializeModeler();
+      setDeploymentLoading(false);
     };
 
     const showCamundaHTTTPErrors = (error) => {
@@ -259,7 +273,9 @@ export default React.memo(
               style={{
                 border: "1px solid #000000",
               }}
-            ></div>
+            >
+              {!deploymentLoading ? null : <Loading />}
+            </div>
             <div
               className="d-flex justify-content-end zoom-container"
               id="zoom-id"


### PR DESCRIPTION
# Issue Tracking

JIRA: [FWF-1700](https://aottech.atlassian.net/browse/FWF-1700)
Issue Type: BUG

# Changes
I believe that the false 'ID must be unique' error in the properties panel happens because the panel compares the ID of the deployed model to the previously cached one, and therefore the ID's are identical and the error is displayed. I have added a refresh method that destroys and initializes the modeler in order to clear the cache. A loading spinner has been added while the modeler is being refreshed. 
