### PR TITLE
Webapi: Keycloak users list search fix

### DIFF
--- a/forms-flow-api/src/formsflow_api/services/user.py
+++ b/forms-flow-api/src/formsflow_api/services/user.py
@@ -23,11 +23,21 @@ class UserService:
         def iter_fun(user):
             search_flag = True
             if params.get("firstName"):
-                search_flag = params.get("firstName") in user["firstName"]
+                search_flag = (
+                    params.get("firstName") in user["firstName"]
+                    if user.get("firstName")
+                    else False
+                )
             if params.get("lastName"):
-                search_flag = params.get("lastName") in user["lastName"]
+                search_flag = (
+                    params.get("lastName") in user["lastName"]
+                    if user.get("lastName")
+                    else False
+                )
             if params.get("email"):
-                search_flag = params.get("email") in user["email"]
+                search_flag = (
+                    params.get("email") in user["email"] if user.get("email") else False
+                )
             return search_flag
 
         return list(filter(iter_fun, user_list))


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG
https://aottech.atlassian.net/browse/FWF-1840

# Changes
When a new user is created in Keycloak without assigning any value for the first name, last name, or email, these fields are not returned in the Keycloak listing API, which causes a key error on these fields while searching.

Added a condition to check whether first name, last name, or email exists in keycloak user list  before searching.

# Screenshots

![image](https://user-images.githubusercontent.com/99173163/201008638-e3b3e358-2705-4e6a-8b48-b4594e7c8d01.png)

**Before fix**
![image](https://user-images.githubusercontent.com/99173163/201008991-25d6f65f-e9ba-4fb7-8a61-c8c4289bda27.png)


**After fix**
![image](https://user-images.githubusercontent.com/99173163/201008778-78acbb34-959f-4258-b360-530fb58a2eff.png)

