### PR TITLE
[BPM Abstraction] FWF-1781 dynamic filter implementation

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/config/ServiceFinder.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/config/ServiceFinder.java
@@ -1,9 +1,13 @@
 package org.camunda.bpm.extension.commons.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.camunda.bpm.engine.AuthorizationService;
+import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.extension.hooks.rest.service.AdminRestService;
+import org.camunda.bpm.extension.hooks.rest.service.FilterRestService;
 import org.camunda.bpm.extension.hooks.rest.service.impl.AdminRestServiceImpl;
+import org.camunda.bpm.extension.hooks.rest.service.impl.FilterRestServiceImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -12,9 +16,14 @@ import org.springframework.stereotype.Component;
 public class ServiceFinder {
 
     private AdminRestService adminRestService;
+    private FilterRestService filterRestService;
 
     public AdminRestService getAdminRestService() {
         return adminRestService;
+    }
+
+    public FilterRestService getFilterRestService() {
+        return filterRestService;
     }
 
     @Bean
@@ -24,5 +33,11 @@ public class ServiceFinder {
     ){
         adminRestService =  new AdminRestServiceImpl(adminGroupName, authorizationService, repositoryService);
         return adminRestService;
+    }
+
+    @Bean
+    public FilterRestService getFilterRestService(ObjectMapper objectMapper, ProcessEngine processEngine) {
+        filterRestService =  new FilterRestServiceImpl(objectMapper, processEngine);
+        return filterRestService;
     }
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/config/ServiceFinder.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/commons/config/ServiceFinder.java
@@ -5,9 +5,9 @@ import org.camunda.bpm.engine.AuthorizationService;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.extension.hooks.rest.service.AdminRestService;
-import org.camunda.bpm.extension.hooks.rest.service.FilterRestService;
+import org.camunda.bpm.extension.hooks.rest.service.TaskFilterRestService;
 import org.camunda.bpm.extension.hooks.rest.service.impl.AdminRestServiceImpl;
-import org.camunda.bpm.extension.hooks.rest.service.impl.FilterRestServiceImpl;
+import org.camunda.bpm.extension.hooks.rest.service.impl.TaskFilterRestServiceImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -16,14 +16,14 @@ import org.springframework.stereotype.Component;
 public class ServiceFinder {
 
     private AdminRestService adminRestService;
-    private FilterRestService filterRestService;
+    private TaskFilterRestService taskFilterRestService;
 
     public AdminRestService getAdminRestService() {
         return adminRestService;
     }
 
-    public FilterRestService getFilterRestService() {
-        return filterRestService;
+    public TaskFilterRestService getTaskFilterRestService() {
+        return taskFilterRestService;
     }
 
     @Bean
@@ -36,8 +36,8 @@ public class ServiceFinder {
     }
 
     @Bean
-    public FilterRestService getFilterRestService(ObjectMapper objectMapper, ProcessEngine processEngine) {
-        filterRestService =  new FilterRestServiceImpl(objectMapper, processEngine);
-        return filterRestService;
+    public TaskFilterRestService getTaskFilterRestService(ObjectMapper objectMapper, ProcessEngine processEngine) {
+        taskFilterRestService =  new TaskFilterRestServiceImpl(objectMapper, processEngine);
+        return taskFilterRestService;
     }
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/FilterRestResource.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/FilterRestResource.java
@@ -1,5 +1,6 @@
 package org.camunda.bpm.extension.hooks.rest;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.engine.rest.dto.runtime.FilterDto;
 import org.camunda.bpm.engine.rest.hal.Hal;
@@ -23,26 +24,11 @@ public interface FilterRestResource extends RestResource {
 
     String PATH = "/filter";
 
-    @GET
-    @Produces(MediaType.APPLICATION_JSON)
-    List<FilterDto> getFilters(@Context UriInfo uriInfo, @QueryParam("itemCount") Boolean itemCount,
-                                          @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults);
-
-    @GET
-    @Path("/{id}/list")
-    @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})
-    Object executeList(@Context Request request, @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults, @PathParam("id") String id);
-
     @POST
-    @Path("/{id}/list")
+    @Path("/tasks")
     @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})
     @Consumes(MediaType.APPLICATION_JSON)
-    Object queryList(@Context Request request, String extendingQuery,
-                     @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults, @PathParam("id") String id);
+    Object queryList(@Context Request request, String extendingQuery, @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults) throws JsonProcessingException;
 
-    @GET
-    @Path("/{id}/count")
-    @Produces(MediaType.APPLICATION_JSON)
-    EntityModel<CountResultDto> executeCount(@PathParam("id") String id);
 
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/FilterRestResource.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/FilterRestResource.java
@@ -1,29 +1,49 @@
 package org.camunda.bpm.extension.hooks.rest;
 
+import org.camunda.bpm.engine.rest.dto.CountResultDto;
+import org.camunda.bpm.engine.rest.dto.runtime.FilterDto;
+import org.camunda.bpm.engine.rest.hal.Hal;
+import org.springframework.hateoas.EntityModel;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Request;
 
-import org.camunda.bpm.engine.rest.hal.Hal;
-import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
+import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 @Produces(MediaType.APPLICATION_JSON)
 public interface FilterRestResource extends RestResource {
 
     String PATH = "/filter";
 
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<FilterDto> getFilters(@Context UriInfo uriInfo, @QueryParam("itemCount") Boolean itemCount,
+                               @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults);
+
+    @GET
+    @Path("/{id}/list")
+    @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})
+    Object executeList(@Context Request request, @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults, @PathParam("id") String id);
+
     @POST
-    @Path("/tasks")
+    @Path("/{id}/list")
     @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})
     @Consumes(MediaType.APPLICATION_JSON)
-    Object queryList(@Context Request request, TaskQueryDto extendingQuery, @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults) throws JsonProcessingException;
+    Object queryList(@Context Request request, String extendingQuery,
+                     @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults, @PathParam("id") String id);
 
+    @GET
+    @Path("/{id}/count")
+    @Produces(MediaType.APPLICATION_JSON)
+    EntityModel<CountResultDto> executeCount(@PathParam("id") String id);
 
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/TaskFilterRestResource.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/TaskFilterRestResource.java
@@ -1,0 +1,21 @@
+package org.camunda.bpm.extension.hooks.rest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.camunda.bpm.engine.rest.hal.Hal;
+import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
+
+@Produces(MediaType.APPLICATION_JSON)
+public interface TaskFilterRestResource {
+	
+    String PATH = "/task-filters";
+
+    @POST
+    @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})
+    @Consumes(MediaType.APPLICATION_JSON)
+    Object queryList(@Context Request request, TaskQueryDto extendingQuery, @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults) throws JsonProcessingException;
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/dto/TaskQueryDto.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/dto/TaskQueryDto.java
@@ -1,0 +1,11 @@
+package org.camunda.bpm.extension.hooks.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Data;
+import org.camunda.bpm.engine.rest.sub.runtime.impl.FilterResourceImpl;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TaskQueryDto extends org.camunda.bpm.engine.rest.dto.task.TaskQueryDto {
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FilterRestResourceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FilterRestResourceImpl.java
@@ -1,50 +1,28 @@
 package org.camunda.bpm.extension.hooks.rest.impl;
 
-import org.camunda.bpm.engine.rest.FilterRestService;
-import org.camunda.bpm.engine.rest.dto.CountResultDto;
-import org.camunda.bpm.engine.rest.dto.runtime.FilterDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.extension.hooks.rest.FilterRestResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.hateoas.EntityModel;
+import org.springframework.stereotype.Component;
 
 import javax.ws.rs.core.Request;
-import javax.ws.rs.core.UriInfo;
-import java.util.List;
 
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
-import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
-
+@Component
 public class FilterRestResourceImpl implements FilterRestResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(FilterRestResourceImpl.class);
 
-    private final FilterRestService restService;
+    private final org.camunda.bpm.extension.hooks.rest.service.FilterRestService restService;
 
-    public FilterRestResourceImpl(FilterRestService filterRestService) {
+    public FilterRestResourceImpl(org.camunda.bpm.extension.hooks.rest.service.FilterRestService filterRestService) {
         restService = filterRestService;
     }
 
     @Override
-    public List<FilterDto> getFilters(UriInfo uriInfo, Boolean itemCount, Integer firstResult, Integer maxResults) {
-        return restService.getFilters(uriInfo, itemCount, firstResult, maxResults);
+    public Object queryList(Request request, String extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException {
+        return restService.queryList(request, extendingQuery, firstResult, maxResults);
     }
 
-    @Override
-    public Object executeList(Request request, Integer firstResult, Integer maxResults, String id) {
-        return restService.getFilter(id).executeList(request, firstResult, maxResults);
 
-    }
-
-    @Override
-    public Object queryList(Request request, String extendingQuery, Integer firstResult, Integer maxResults, String id) {
-        return restService.getFilter(id).queryList(request, extendingQuery, firstResult, maxResults);
-
-    }
-
-    @Override
-    public EntityModel<CountResultDto> executeCount(String id) {
-        CountResultDto dto = restService.getFilter(id).executeCount();
-        return EntityModel.of(dto, linkTo(methodOn(FilterRestResourceImpl.class).executeCount(id)).withSelfRel().withSelfRel());
-    }
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FilterRestResourceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FilterRestResourceImpl.java
@@ -1,30 +1,55 @@
 package org.camunda.bpm.extension.hooks.rest.impl;
 
-import javax.ws.rs.core.Request;
-
+import org.camunda.bpm.engine.rest.FilterRestService;
+import org.camunda.bpm.engine.rest.dto.CountResultDto;
+import org.camunda.bpm.engine.rest.dto.runtime.FilterDto;
 import org.camunda.bpm.extension.hooks.rest.FilterRestResource;
-import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import org.springframework.hateoas.EntityModel;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
 
-@Component
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Deprecated
 public class FilterRestResourceImpl implements FilterRestResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(FilterRestResourceImpl.class);
 
-    private final org.camunda.bpm.extension.hooks.rest.service.FilterRestService restService;
+    private final FilterRestService restService;
 
-    public FilterRestResourceImpl(org.camunda.bpm.extension.hooks.rest.service.FilterRestService filterRestService) {
+    public FilterRestResourceImpl(FilterRestService filterRestService) {
         restService = filterRestService;
     }
 
+    @Deprecated
     @Override
-    public Object queryList(Request request, TaskQueryDto extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException {
-        return restService.queryList(request, extendingQuery, firstResult, maxResults);
+    public List<FilterDto> getFilters(UriInfo uriInfo, Boolean itemCount, Integer firstResult, Integer maxResults) {
+        return restService.getFilters(uriInfo, itemCount, firstResult, maxResults);
     }
 
+    @Deprecated
+    @Override
+    public Object executeList(Request request, Integer firstResult, Integer maxResults, String id) {
+        return restService.getFilter(id).executeList(request, firstResult, maxResults);
 
+    }
+
+    @Deprecated
+    @Override
+    public Object queryList(Request request, String extendingQuery, Integer firstResult, Integer maxResults, String id) {
+        return restService.getFilter(id).queryList(request, extendingQuery, firstResult, maxResults);
+
+    }
+
+    @Deprecated
+    @Override
+    public EntityModel<CountResultDto> executeCount(String id) {
+        CountResultDto dto = restService.getFilter(id).executeCount();
+        return EntityModel.of(dto, linkTo(methodOn(FilterRestResourceImpl.class).executeCount(id)).withSelfRel().withSelfRel());
+    }
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FormsFlowV1RestServiceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FormsFlowV1RestServiceImpl.java
@@ -46,7 +46,7 @@ public class FormsFlowV1RestServiceImpl {
 
     @Path(FilterRestResource.PATH)
     public FilterRestResource getFilterResource() {
-        return new FilterRestResourceImpl(serviceFinder.getFilterRestService());
+        return new FilterRestResourceImpl(processEngineService.getFilterRestService());
     }
 
     @Path(MessageRestResource.PATH)
@@ -67,6 +67,11 @@ public class FormsFlowV1RestServiceImpl {
     @Path(VersionRestResource.PATH)
     public VersionRestResource getVersion() {
         return new VersionRestResourceImpl(processEngineService.getVersionRestService());
+    }
+
+    @Path(TaskFilterRestResource.PATH)
+    public TaskFilterRestResource getTaskFilterResource() {
+        return new TaskFilterRestResourceImpl(serviceFinder.getTaskFilterRestService());
     }
 
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FormsFlowV1RestServiceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FormsFlowV1RestServiceImpl.java
@@ -46,7 +46,7 @@ public class FormsFlowV1RestServiceImpl {
 
     @Path(FilterRestResource.PATH)
     public FilterRestResource getFilterResource() {
-        return new FilterRestResourceImpl(processEngineService.getFilterRestService());
+        return new FilterRestResourceImpl(serviceFinder.getFilterRestService());
     }
 
     @Path(MessageRestResource.PATH)

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/TaskFilterRestResourceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/TaskFilterRestResourceImpl.java
@@ -1,0 +1,27 @@
+package org.camunda.bpm.extension.hooks.rest.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.camunda.bpm.extension.hooks.rest.TaskFilterRestResource;
+import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.core.Request;
+
+@Component
+public class TaskFilterRestResourceImpl implements TaskFilterRestResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TaskFilterRestResourceImpl.class);
+
+    private final org.camunda.bpm.extension.hooks.rest.service.TaskFilterRestService restService;
+
+    public TaskFilterRestResourceImpl(org.camunda.bpm.extension.hooks.rest.service.TaskFilterRestService taskFilterRestService) {
+        restService = taskFilterRestService;
+    }
+
+    @Override
+    public Object queryList(Request request, TaskQueryDto extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException {
+        return restService.queryList(request, extendingQuery, firstResult, maxResults);
+    }
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/FilterRestService.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/FilterRestService.java
@@ -1,0 +1,10 @@
+package org.camunda.bpm.extension.hooks.rest.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import javax.ws.rs.core.Request;
+
+public interface FilterRestService {
+
+    Object queryList(Request request, String extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException;
+}

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/TaskFilterRestService.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/TaskFilterRestService.java
@@ -6,7 +6,7 @@ import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-public interface FilterRestService {
+public interface TaskFilterRestService {
 
     Object queryList(Request request, TaskQueryDto extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException;
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/impl/FilterRestServiceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/impl/FilterRestServiceImpl.java
@@ -10,7 +10,6 @@ import javax.ws.rs.core.Variant;
 
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.query.Query;
-import org.camunda.bpm.engine.rest.dto.AbstractQueryDto;
 import org.camunda.bpm.engine.rest.dto.task.TaskDto;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
 import org.camunda.bpm.engine.rest.hal.Hal;
@@ -26,8 +25,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class FilterRestServiceImpl implements FilterRestService {
-    public static final List<Variant> VARIANTS = Variant.mediaTypes(MediaType.APPLICATION_JSON_TYPE, Hal.APPLICATION_HAL_JSON_TYPE).add().build();
+    
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterRestServiceImpl.class);
+    
+    public static final List<Variant> VARIANTS = Variant.mediaTypes(MediaType.APPLICATION_JSON_TYPE, Hal.APPLICATION_HAL_JSON_TYPE).add().build();
     private final ObjectMapper objectMapper;
     private final ProcessEngine processEngine;
 
@@ -49,15 +50,11 @@ public class FilterRestServiceImpl implements FilterRestService {
         if (maxResults == null) {
             maxResults = Integer.MAX_VALUE;
         }
-//        ((TaskQuery) query).initializeFormKeys();
-//        ((AbstractQuery) query).enableMaxResultsLimit();
         return executeList(request, executeQuery(filterQuery.getCriteria()), firstResult, maxResults);
     }
 
     private Query executeQuery(org.camunda.bpm.engine.rest.dto.task.TaskQueryDto extendingQuery) throws JsonProcessingException {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        
-//        AbstractQueryDto<?> queryDto = objectMapper.readValue(extendingQuery, TaskQueryDto.class);
         extendingQuery.setObjectMapper(objectMapper);
         return extendingQuery.toQuery(processEngine);
     }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/impl/FilterRestServiceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/impl/FilterRestServiceImpl.java
@@ -1,0 +1,91 @@
+package org.camunda.bpm.extension.hooks.rest.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.impl.AbstractQuery;
+import org.camunda.bpm.engine.query.Query;
+import org.camunda.bpm.engine.rest.dto.AbstractQueryDto;
+import org.camunda.bpm.engine.rest.dto.task.TaskDto;
+import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
+import org.camunda.bpm.engine.rest.hal.Hal;
+import org.camunda.bpm.engine.rest.hal.task.HalTaskList;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.task.TaskQuery;
+import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
+import org.camunda.bpm.extension.hooks.rest.service.FilterRestService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Variant;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FilterRestServiceImpl implements FilterRestService {
+    public static final List<Variant> VARIANTS = Variant.mediaTypes(MediaType.APPLICATION_JSON_TYPE, Hal.APPLICATION_HAL_JSON_TYPE).add().build();
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilterRestServiceImpl.class);
+    private final ObjectMapper objectMapper;
+    private final ProcessEngine processEngine;
+
+    public FilterRestServiceImpl(ObjectMapper objectMapper, ProcessEngine processEngine) {
+        this.objectMapper = objectMapper;
+        this.processEngine = processEngine;
+    }
+
+    @Override
+    public Object queryList(Request request, String extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException {
+        return executeQueryList(request, extendingQuery, firstResult, maxResults);
+
+    }
+
+    private Object executeQueryList(Request request, String extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException {
+        if (firstResult == null) {
+            firstResult = 0;
+        }
+        if (maxResults == null) {
+            maxResults = Integer.MAX_VALUE;
+        }
+//        ((TaskQuery) query).initializeFormKeys();
+//        ((AbstractQuery) query).enableMaxResultsLimit();
+        return executeList(request, executeQuery(extendingQuery), firstResult, maxResults);
+    }
+
+    private Query executeQuery(String extendingQuery) throws JsonProcessingException {
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        AbstractQueryDto<?> queryDto = objectMapper.readValue(extendingQuery, TaskQueryDto.class);
+        queryDto.setObjectMapper(objectMapper);
+        return queryDto.toQuery(processEngine);
+    }
+
+    private Object executeList(Request request, Query query, Integer firstResult, Integer maxResults) {
+        Variant variant = request.selectVariant(VARIANTS);
+        if (variant != null) {
+            if (MediaType.APPLICATION_JSON_TYPE.equals(variant.getMediaType())) {
+                return queryJsonList(query);
+            } else if (Hal.APPLICATION_HAL_JSON_TYPE.equals(variant.getMediaType())) {
+                return queryHalList(query, firstResult, maxResults);
+            }
+        }
+        throw new InvalidRequestException(Response.Status.NOT_ACCEPTABLE, "No acceptable content-type found");
+    }
+
+    private Object queryHalList(Query query, Integer firstResult, Integer maxResults) {
+        List<Task> entities = query.listPage(firstResult, maxResults);
+        return HalTaskList.generate(entities, query.count(), processEngine);
+    }
+
+    public List<Object> queryJsonList(Query query) {
+        List<?> entities = query.list();
+        List<Object> dtoList = new ArrayList<>();
+        for (Object entity : entities) {
+            dtoList.add(TaskDto.fromEntity((Task) entity));
+        }
+        return dtoList;
+    }
+
+}
+

--- a/forms-flow-bpm/src/test/java/org/camunda/bpm/extension/hooks/rest/service/impl/TaskFilterRestServiceImplTest.java
+++ b/forms-flow-bpm/src/test/java/org/camunda/bpm/extension/hooks/rest/service/impl/TaskFilterRestServiceImplTest.java
@@ -1,0 +1,131 @@
+package org.camunda.bpm.extension.hooks.rest.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.camunda.bpm.engine.ProcessEngine;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.rest.hal.Hal;
+import org.camunda.bpm.engine.task.TaskQuery;
+import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Variant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+public class TaskFilterRestServiceImplTest {
+
+	@InjectMocks
+	private TaskFilterRestServiceImpl filterRestServiceImpl;
+
+	@Mock
+	private ProcessEngine processEngine;
+
+	@Mock
+	private Request request;
+
+	@Mock
+	private TaskService taskService;
+
+	@Mock
+	private TaskQuery taskQuery;
+
+	@Mock
+	private ObjectMapper objectMapper;
+
+	@Mock
+	private Variant variant;
+
+	/**
+	 * This test case perform a positive test over execute method in FilterRestServiceImpl
+	 */
+	@Test
+	public void execute_filterQuery_jsonList() throws JsonProcessingException {
+		TaskQueryDto querydto = mock(TaskQueryDto.class);
+		org.camunda.bpm.engine.rest.dto.task.TaskQueryDto taskdto = new org.camunda.bpm.engine.rest.dto.task.TaskQueryDto();
+		taskdto.setAssignee("John Honai");
+		taskdto.setProcessDefinitionName("Two Step Approval");
+		when(querydto.getCriteria()).thenReturn(taskdto);
+		when(processEngine.getTaskService())
+				.thenReturn(taskService);
+		taskQuery.taskAssignee(querydto.getCriteria().getAssignee());
+		taskQuery.processDefinitionName(querydto.getCriteria().getProcessDefinitionName());
+		when(taskService.createTaskQuery())
+				.thenReturn(taskQuery);
+		when(request.selectVariant(any()))
+				.thenReturn(variant);
+		when(variant.getMediaType())
+				.thenReturn(MediaType.APPLICATION_JSON_TYPE);
+		filterRestServiceImpl.queryList(request, querydto, null, null);
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(taskQuery, times(2)).taskAssignee(captor.capture());
+		assertEquals("John Honai", captor.getValue());
+	}
+
+	/**
+	 * This test case perform a positive test over execute method in FilterRestServiceImpl 
+	 * This test will execute the query to return hal tasklist
+	 */
+	@Test
+	public void execute_filterQuery_halList() throws JsonProcessingException {
+		TaskQueryDto querydto = mock(TaskQueryDto.class);
+		org.camunda.bpm.engine.rest.dto.task.TaskQueryDto taskdto = new org.camunda.bpm.engine.rest.dto.task.TaskQueryDto();
+		taskdto.setAssignee("John Honai");
+		taskdto.setProcessDefinitionName("Two Step Approval");
+		when(querydto.getCriteria()).thenReturn(taskdto);
+		when(processEngine.getTaskService())
+				.thenReturn(taskService);
+		taskQuery.taskAssignee(querydto.getCriteria().getAssignee());
+		taskQuery.processDefinitionName(querydto.getCriteria().getProcessDefinitionName());
+		when(taskService.createTaskQuery())
+				.thenReturn(taskQuery);
+		when(request.selectVariant(any()))
+				.thenReturn(variant);
+		when(variant.getMediaType())
+				.thenReturn(Hal.APPLICATION_HAL_JSON_TYPE);
+		filterRestServiceImpl.queryList(request, querydto, null, null);
+		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+		verify(taskQuery, times(2)).processDefinitionName(captor.capture());
+		assertEquals("Two Step Approval", captor.getValue());
+	}
+
+	/**
+	 * This test case will evaluate TaskFilterRestServiceImpl with a negative case
+	 * This test case expects a JsonProcessingException 
+	 * Expectation will be to fail the case with Runtime Exception
+	 * @throws InvalidRequestException
+	 */
+	@Test
+	public void execute_filterQuery_with_invalid_mediatype() throws JsonProcessingException {
+		TaskQueryDto querydto = mock(TaskQueryDto.class);
+		org.camunda.bpm.engine.rest.dto.task.TaskQueryDto taskdto = new org.camunda.bpm.engine.rest.dto.task.TaskQueryDto();
+		taskdto.setAssignee("John Honai");
+		taskdto.setProcessDefinitionName("Two Step Approval");
+		when(querydto.getCriteria()).thenReturn(taskdto);
+		when(processEngine.getTaskService())
+				.thenReturn(taskService);
+		taskQuery.taskAssignee(querydto.getCriteria().getAssignee());
+		taskQuery.processDefinitionName(querydto.getCriteria().getProcessDefinitionName());
+		when(taskService.createTaskQuery())
+				.thenReturn(taskQuery);
+		when(request.selectVariant(any()))
+				.thenReturn(variant);
+		when(variant.getMediaType())
+				.thenReturn(MediaType.APPLICATION_XML_TYPE);
+		assertThrows(RuntimeException.class, () -> {
+			filterRestServiceImpl.queryList(request, querydto, null, null);
+		});
+	}
+
+}


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type:FEATURE
https://aottech.atlassian.net/browse/FWF-1781

# Changes

* added dynamic filter implementation in forms-flow-bpm.
* BPM gets filter parameters from UI, and implement the logic to return the tasklist.
* New endpoint created to return the tasklist: `/task-filters`


# How has the change been tested?


# Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/85665463/202086850-835d37af-79c5-486a-a29a-9d02053cf6e6.png)


# Build Success screenshot (Till a CICD pipeline is set up)


# Notes