### PR TITLE
added task filter count API FWF-1872

### DIFF
--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/TaskFilterRestResource.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/TaskFilterRestResource.java
@@ -1,8 +1,11 @@
 package org.camunda.bpm.extension.hooks.rest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.engine.rest.hal.Hal;
 import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
+import org.springframework.hateoas.EntityModel;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
@@ -18,4 +21,11 @@ public interface TaskFilterRestResource {
     @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})
     @Consumes(MediaType.APPLICATION_JSON)
     Object queryList(@Context Request request, TaskQueryDto extendingQuery, @QueryParam("firstResult") Integer firstResult, @QueryParam("maxResults") Integer maxResults) throws JsonProcessingException;
+
+    @POST
+    @Path("/count")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    EntityModel<CountResultDto> queryCount(TaskQueryDto filterQuery);
+    
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/TaskFilterRestResourceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/TaskFilterRestResourceImpl.java
@@ -1,11 +1,17 @@
 package org.camunda.bpm.extension.hooks.rest.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.extension.hooks.rest.TaskFilterRestResource;
 import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 import javax.ws.rs.core.Request;
 
@@ -24,4 +30,11 @@ public class TaskFilterRestResourceImpl implements TaskFilterRestResource {
     public Object queryList(Request request, TaskQueryDto extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException {
         return restService.queryList(request, extendingQuery, firstResult, maxResults);
     }
+
+	@Override
+	public EntityModel<CountResultDto> queryCount(TaskQueryDto filterQuery) {
+		CountResultDto dto = restService.queryCount(filterQuery);
+		return EntityModel.of(dto,
+				linkTo(methodOn(TaskFilterRestResourceImpl.class).queryCount(filterQuery)).withSelfRel());
+	}
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/TaskFilterRestService.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/TaskFilterRestService.java
@@ -2,6 +2,7 @@ package org.camunda.bpm.extension.hooks.rest.service;
 
 import javax.ws.rs.core.Request;
 
+import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -9,4 +10,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 public interface TaskFilterRestService {
 
     Object queryList(Request request, TaskQueryDto extendingQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException;
+
+    CountResultDto queryCount(TaskQueryDto filterQuery);
 }

--- a/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/impl/TaskFilterRestServiceImpl.java
+++ b/forms-flow-bpm/src/main/java/org/camunda/bpm/extension/hooks/rest/service/impl/TaskFilterRestServiceImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.query.Query;
+import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.engine.rest.dto.task.TaskDto;
 import org.camunda.bpm.engine.rest.exception.InvalidRequestException;
 import org.camunda.bpm.engine.rest.hal.Hal;
@@ -40,6 +41,22 @@ public class TaskFilterRestServiceImpl implements TaskFilterRestService {
         return executeQueryList(request, filterQuery, firstResult, maxResults);
 
     }
+    
+	@Override
+	public CountResultDto queryCount(TaskQueryDto filterQuery) {
+		return new CountResultDto(executeFilterCount(filterQuery));
+	}
+	
+	/**
+	 * This method execute the query and returns the count
+	 *
+	 * @param filterQuery
+	 * @return
+	 */
+	protected long executeFilterCount(TaskQueryDto filterQuery) {
+		Query<?, ?> query = filterQuery.getCriteria().toQuery(processEngine);
+		return query.count();
+	}
 
     private Object executeQueryList(Request request, TaskQueryDto filterQuery, Integer firstResult, Integer maxResults) throws JsonProcessingException {
         if (firstResult == null) {

--- a/forms-flow-bpm/src/test/java/org/camunda/bpm/extension/hooks/rest/service/impl/TaskFilterRestServiceImplTest.java
+++ b/forms-flow-bpm/src/test/java/org/camunda/bpm/extension/hooks/rest/service/impl/TaskFilterRestServiceImplTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.engine.rest.hal.Hal;
 import org.camunda.bpm.engine.task.TaskQuery;
 import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;
@@ -126,6 +127,22 @@ public class TaskFilterRestServiceImplTest {
 		assertThrows(RuntimeException.class, () -> {
 			filterRestServiceImpl.queryList(request, querydto, null, null);
 		});
+	}
+	
+	@Test
+	public void invoke_filterCount_with_success() throws JsonProcessingException {
+		TaskQueryDto querydto = mock(TaskQueryDto.class);
+		org.camunda.bpm.engine.rest.dto.task.TaskQueryDto taskdto = new org.camunda.bpm.engine.rest.dto.task.TaskQueryDto();
+		taskdto.setAssignee("John Honai");
+		taskdto.setProcessDefinitionName("Two Step Approval");
+		when(querydto.getCriteria()).thenReturn(taskdto);
+		when(processEngine.getTaskService()).thenReturn(taskService);
+		taskQuery.taskAssignee(querydto.getCriteria().getAssignee());
+		taskQuery.processDefinitionName(querydto.getCriteria().getProcessDefinitionName());
+		when(taskQuery.count()).thenReturn(2L);
+		when(taskService.createTaskQuery()).thenReturn(taskQuery);
+		filterRestServiceImpl.queryCount(querydto);
+		verify(taskQuery, times(1)).count();		
 	}
 
 }

--- a/forms-flow-bpm/src/test/java/org/camunda/bpm/extension/hooks/rest/service/impl/TaskFilterRestServiceImplTest.java
+++ b/forms-flow-bpm/src/test/java/org/camunda/bpm/extension/hooks/rest/service/impl/TaskFilterRestServiceImplTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.TaskService;
-import org.camunda.bpm.engine.rest.dto.CountResultDto;
 import org.camunda.bpm.engine.rest.hal.Hal;
 import org.camunda.bpm.engine.task.TaskQuery;
 import org.camunda.bpm.extension.hooks.rest.dto.TaskQueryDto;


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-1872

# Changes
* Added task filter count API to BPM layer, added testcases, New endpoint to retrieve the count will be `/task-filters/count`.

# How has the change been tested?

# Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/85665463/205620795-2ccd8094-6616-4127-9164-4e7bea16dd7a.png)

# Notes

