### PR TITLE
✅ : flake8 version downgraded to 5.0.4

### DIFF
--- a/forms-flow-api/requirements/dev.txt
+++ b/forms-flow-api/requirements/dev.txt
@@ -1,7 +1,7 @@
 -r prod.txt
 autopep8
 black
-flake8
+flake8==5.0.4
 flake8-blind-except
 flake8-debugger
 flake8-docstrings

--- a/forms-flow-data-analysis-api/requirements/dev.txt
+++ b/forms-flow-data-analysis-api/requirements/dev.txt
@@ -10,7 +10,7 @@ pytest-cov
 FreezeGun
 
 # Lint and code style
-flake8
+flake8==5.0.4
 flake8-blind-except
 flake8-debugger
 flake8-docstrings

--- a/forms-flow-documents/requirements/dev.txt
+++ b/forms-flow-documents/requirements/dev.txt
@@ -1,7 +1,7 @@
 -r prod.txt
 autopep8
 black
-flake8
+flake8==5.0.4
 flake8-blind-except
 flake8-debugger
 flake8-docstrings


### PR DESCRIPTION
The latest flake8 has incompatibilities with the `flake8-quotes` plugin.
