### PR TITLE
 Fix Form Name doesn't appear in Metrics page when using the Modified Date filter.

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/application.py
+++ b/forms-flow-api/src/formsflow_api/models/application.py
@@ -573,7 +573,7 @@ class Application(
         """Get application status w.r.t to mapper_id ordered by modified date."""
         result_proxy = (
             db.session.query(
-                FormProcessMapper.form_name,
+                FormProcessMapper.form_name.label("application_name"),
                 Application.application_status,
                 func.count(FormProcessMapper.form_name).label("count"),
             )


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG
https://aottech.atlassian.net/browse/FWF-1953

# Changes
Form Name doesn't appear in Metrics page on filter with Modified Date issue fix.

# Screenshots 
![image](https://user-images.githubusercontent.com/99173163/208634580-358f8762-c143-434f-b817-8d933480bd4e.png)

