### PR TITLE
Metrics pi chart data overlaping issue fix.

### DIFF
--- a/forms-flow-web/src/components/Dashboard/StatusChart.js
+++ b/forms-flow-web/src/components/Dashboard/StatusChart.js
@@ -42,6 +42,8 @@ const ChartForm = React.memo((props) => {
             <div className="chart text-center">
               <PieChart width={400} height={400}>
                 <Pie
+                  paddingAngle={1}
+                  minAngle={1}
                   data={pieData}
                   labelLine={false}
                   outerRadius={90}


### PR DESCRIPTION
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-1884
Issue Type: BUG

# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->
The pichart data was ovelaping when the pidata gets smaller. 
# How has the change been tested?
<!-- 
Unit tests, Integration tests, Manual verification, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->
![image](https://user-images.githubusercontent.com/83585487/209918730-42c99850-b144-4e1c-bd25-c8fc12a93639.png)
fix: 
![image](https://user-images.githubusercontent.com/83585487/209918812-b18c6fd2-059f-414d-9055-7fbc1f61bf2c.png)

# Build Success screenshot (Till a CICD pipeline is set up)
<!-- 
Add a screenshot of the local execution of a successful build.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->
this is a possible bug that reportd by many others too in gitissues that the group responsible doesnot provide an exact solution for this. ref: https://github.com/recharts/recharts/issues/490