### PR TITLE
🐛 : Task failure for external embed API

### DIFF
--- a/forms-flow-api/src/formsflow_api/resources/form_embed.py
+++ b/forms-flow-api/src/formsflow_api/resources/form_embed.py
@@ -45,7 +45,7 @@ class EmbedCommonMethods:
             return err.error, err.status_code
 
     @staticmethod
-    def post():
+    def post(token=None):
         """Post a new application using the request body."""
         formio_url = current_app.config.get("FORMIO_URL")
         web_url = current_app.config.get("WEB_BASE_URL")
@@ -55,7 +55,7 @@ class EmbedCommonMethods:
                 response,
                 status,
             ) = CombineFormAndApplicationCreate.application_create_with_submission(
-                data, formio_url, web_url, request.headers["Authorization"]
+                data, formio_url, web_url, token
             )
             return response, status
         except BusinessException as err:
@@ -163,7 +163,7 @@ class ApplicationCreateInternal(Resource):
         }
         ```
         """
-        return EmbedCommonMethods.post()
+        return EmbedCommonMethods.post(request.headers["Authorization"])
 
 
 @cors_preflight("GET,OPTIONS")

--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -85,7 +85,7 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
         user: UserContext = kwargs["user"]
         user_id: str = user.user_name
         tenant_key = user.tenant_key
-        if token is not None:
+        if user_id is not None:
             # for anonymous form submission
             data["created_by"] = user_id
         data["application_status"] = NEW_APPLICATION_STATUS


### PR DESCRIPTION
The bug was caused by passing the custom
authentication token for initializing
tasks instead of service account token.

The bug is fixed by passing the auth token
only for internal authentication API and
None for external API where the service
account token is used by default.


