### PR TITLE
🐛 fixed form history version number

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Edit.js
@@ -71,7 +71,7 @@ const Edit = React.memo(() => {
   const [form, dispatchFormAction] = useReducer(reducer, _cloneDeep(formData));
   const errors = useSelector((state) => state.form.error);
   const formHistory = useSelector((state)=> state.formRestore?.formHistory || []);
-  const [version, setVersion] = useState(null); 
+  const version = formHistory[0]?.changeLog?.version;
   const prviousData = useSelector((state) => state.process.formPreviousData);
   const applicationCount = useSelector(
     (state) => state.process.applicationCount
@@ -120,21 +120,7 @@ const Edit = React.memo(() => {
   },[processListData]);
 
 
-  useEffect(()=>{
-    if(formHistory?.length){
-      if( formHistory[0].changeLog?.version){
-        setVersion(formHistory[0].changeLog?.version);
-      }else{
-        const versionCount = formHistory.reduce((count,item)=>{
-          if(item.changeLog.new_version){
-            count++;
-          }
-          return count;
-        },0);
-        setVersion(`V${versionCount}`);
-      }
-    }
-  },[formHistory]);
+ 
 
   useEffect(() => {
     if (restoredFormId) {

--- a/forms-flow-web/src/components/Form/Item/FormHistoryModal.js
+++ b/forms-flow-web/src/components/Form/Item/FormHistoryModal.js
@@ -20,10 +20,6 @@ const FormHistoryModal = ({ historyModal, handleModalChange, gotoEdit }) => {
     setSliceFormHistory(formHistory?.slice(0, showCount));
   },[showCount,formHistory]);
 
- 
-
- 
-
   useEffect(() => {
     historyRef?.current?.lastElementChild.scrollIntoView({
       behavior: "smooth",

--- a/forms-flow-web/src/components/Form/Item/Preview.js
+++ b/forms-flow-web/src/components/Form/Item/Preview.js
@@ -63,8 +63,6 @@ const Preview = ({handleNext, hideComponents, activeStep}) => {
   const handlePublishAsNewVersion = ()=>{
     setNewpublishClicked(true);
     setConfirmPublishModal(!confirmPublishModal);
-
-
     const newFormData = manipulatingFormData(
       _.cloneDeep(form),
       MULTITENANCY_ENABLED,
@@ -79,6 +77,7 @@ const Preview = ({handleNext, hideComponents, activeStep}) => {
     newFormData.name = newPathAndName;
     newFormData.componentChanged = true;
     delete newFormData.machineName;
+    delete newFormData.parentFormId;
     newFormData.newVersion = true;
     delete newFormData._id;
     formCreate(newFormData)

--- a/forms-flow-web/src/helper/formHistory.js
+++ b/forms-flow-web/src/helper/formHistory.js
@@ -1,0 +1,26 @@
+/**
+ * 
+ * @param {Array} formHistory 
+ */
+export const setVersionNumberIfNotExist = (formHistory)=>{
+    let versionNumber = 0;
+    if(formHistory[0]?.chageLog?.version){
+        versionNumber = +formHistory[0]?.chageLog?.version.replace("v","");
+    }else{
+        versionNumber = formHistory.reduce((count,item)=>{
+            if(item.changeLog.new_version){
+              count++;
+            }
+            return count;
+          },0);
+    }
+    return formHistory.map((history)=>{
+        const {changeLog} = history;
+        changeLog.version = (
+            changeLog.version ? changeLog.version : (
+                changeLog.new_version ? `v${--versionNumber}` : `v${versionNumber}` 
+            )
+        );
+        return history;
+    });
+};

--- a/forms-flow-web/src/helper/formHistory.js
+++ b/forms-flow-web/src/helper/formHistory.js
@@ -18,9 +18,10 @@ export const setVersionNumberIfNotExist = (formHistory)=>{
         const {changeLog} = history;
         changeLog.version = (
             changeLog.version ? changeLog.version : (
-                changeLog.new_version ? `v${--versionNumber}` : `v${versionNumber}` 
+                changeLog.new_version ? `v${versionNumber}` : `v${versionNumber}` 
             )
         );
+        versionNumber--;
         return history;
     });
 };

--- a/forms-flow-web/src/modules/RestoreFormReducer.js
+++ b/forms-flow-web/src/modules/RestoreFormReducer.js
@@ -1,4 +1,5 @@
 import ACTION_CONSTANTS from "../actions/actionConstants";
+import { setVersionNumberIfNotExist } from "../helper/formHistory";
 
 const initialState = {
   restoredFormData: {},
@@ -14,7 +15,7 @@ const RestoreFormReducer = (state = initialState, action) => {
     case ACTION_CONSTANTS.RESTORE_FORM_DATA:
       return { ...state, restoredFormData: action.payload };
     case ACTION_CONSTANTS.FORM_HISTORY:
-      return { ...state, formHistory: action.payload };
+      return { ...state, formHistory: setVersionNumberIfNotExist(action.payload)};
     default:
       return state;
   }


### PR DESCRIPTION
1. fixed old form version shown in form history: now  showing the version number
2. fixed duplicate form history: deleting parentFormId from form data
3. fixed typo in the edit window
## Before
![image](https://user-images.githubusercontent.com/95394061/216335493-17efb227-98a0-4245-8545-5ee10d9a5715.png)

## After 
![image](https://user-images.githubusercontent.com/95394061/216336213-883cf525-5836-4440-b251-e2f1df4933a7.png)

