### PR TITLE
Form pagination issue on clearing the search kery after selecting the…

### DIFF
--- a/forms-flow-web/src/components/Form/List.js
+++ b/forms-flow-web/src/components/Form/List.js
@@ -202,8 +202,8 @@ const List = React.memo((props) => {
   };
   const handleSearch = () => {
     if (searchText != searchInputBox.current.value) {
+      searchInputBox.current.value === '' ? dispatch(setBPMFormLimit(5)) : '';
       dispatch(setBPMFormListPage(1));
-
       dispatch(setBpmFormSearch(searchInputBox.current.value));
     }
   };


### PR DESCRIPTION
… all in limit filter.

# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-2011
Issue Type: BUG

# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->
The pagination was not being reset to the default limit while clearing the search key setting the lint to all after a search. 

# How has the change been tested?
<!-- 
Unit tests, Integration tests, Manual verification, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->
![image](https://user-images.githubusercontent.com/83585487/217154979-44e7cca0-2dfc-43f7-b3df-a69be18c002c.png)

# Build Success screenshot (Till a CICD pipeline is set up)
<!-- 
Add a screenshot of the local execution of a successful build.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->
