### PR TITLE
metrics with form version rework

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/application.py
+++ b/forms-flow-api/src/formsflow_api/models/application.py
@@ -458,12 +458,12 @@ class Application(
         if order_by == MetricsState.MODIFIED.value:
             order = "modified"
 
-        #to get the max form id to take the latest form name
+        # to get the max form id to take the latest form name
         max_form_id = (
             db.session.query(
                 FormProcessMapper.form_id.label("form_id"),
                 FormProcessMapper.parent_form_id.label("parent_form_id"),
-                db.func.max(FormProcessMapper.id).label("id") # pylint: disable=not-callable
+                db.func.max(FormProcessMapper.id).label("id")  # pylint: disable=not-callable
             ).group_by(
                 FormProcessMapper.form_id,
                 FormProcessMapper.parent_form_id,
@@ -484,7 +484,7 @@ class Application(
             .filter(getattr(Application, order).between(from_date, to_date))
             .group_by(max_form_id.c.parent_form_id)
             .subquery("subquery_application_count"))
-        #taking latest form name
+        # taking latest form name
         latest_form_name = (
             db.session.query(
                 subquery_application_count.c.parent_form_id,

--- a/forms-flow-api/src/formsflow_api/models/application.py
+++ b/forms-flow-api/src/formsflow_api/models/application.py
@@ -488,7 +488,7 @@ class Application(
         latest_form_name = (
             db.session.query(
                 subquery_application_count.c.parent_form_id,
-                FormProcessMapper.form_name,
+                FormProcessMapper.form_name.label("form_name"),
                 subquery_application_count.c.application_count,
             ).join(
                 subquery_application_count,
@@ -544,7 +544,7 @@ class Application(
         result_proxy = FormProcessMapper.tenant_authorization(result_proxy)
         if form_name:
             result_proxy = result_proxy.filter(
-                subquery_application_count.c.form_name.ilike(f"%{form_name}%")
+                latest_form_name.c.form_name.ilike(f"%{form_name}%")
             )
 
         sort_by, sort_order = validate_sort_order_and_order_by(sort_by, sort_order)

--- a/forms-flow-api/src/formsflow_api/schemas/aggregated_application.py
+++ b/forms-flow-api/src/formsflow_api/schemas/aggregated_application.py
@@ -48,5 +48,5 @@ class AggregatedApplicationsSchema(Schema):
 
     parent_form_id = fields.Str(data_key="parentFormId")
     form_versions = fields.List(fields.Dict, data_key="formVersions")
-    submission_count = fields.Integer(data_key="applicationCount")
+    submission_count = fields.Str(data_key="applicationCount")
     form_name = fields.Str(data_key="formName")

--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -368,6 +368,7 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
             sort_order=sort_order,
             order_by=order_by,
         )
+
         schema = AggregatedApplicationsSchema()
         return (
             schema.dump(applications, many=True),

--- a/forms-flow-web/src/components/Dashboard/StatusChart.js
+++ b/forms-flow-web/src/components/Dashboard/StatusChart.js
@@ -1,9 +1,8 @@
-import React, { useMemo } from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import LoadingOverlay from "react-loading-overlay";
 
 import { Legend, PieChart, Pie, Cell, LabelList } from "recharts";
-import { sortAlphaNum } from "../../helper/helper";
 
 const COLORS = [
   "#0088FE",
@@ -21,26 +20,7 @@ const ChartForm = React.memo((props) => {
   const { submissionsStatusList, submissionData, submissionStatusCountLoader } = props;
   const {formVersions, formName, parentFormId} = submissionData;
 
-  /* ----------------------- check form versions is null ---------------------- */
-  const checkedFormVersions =  useMemo(()=> {
-    if(formVersions[formVersions.length - 1].version){
-      return formVersions;
-      }
-    return formVersions.map((i,index)=>i.version === null ? 
-           {...i, version:`v${index + 1}`} : i );
-  },[formVersions]);
-
-  /* sometimes formVersions array not 
-    sorted by version so need to sort by asc order */
-  const sortedFormVersions = useMemo(()=>{
-    if(checkedFormVersions.length > 1   ){
-      return sortAlphaNum({data:checkedFormVersions,key:"version",order:"asc"});
-    }
-    return checkedFormVersions;
-  },[formVersions]);
-
-
-  const version = checkedFormVersions?.length;
+  const version = formVersions?.length;
 
   const { t } = useTranslation();
   const pieData = submissionsStatusList || [];
@@ -70,13 +50,13 @@ const ChartForm = React.memo((props) => {
           </p>
           </div>
           {
-            sortedFormVersions.length > 1 ? (
+            formVersions.length > 1 ? (
               <div className="col-3">
             <p className="form-label mb-0">Select form version</p>
             <select className="form-select" aria-label="Default select example"  onChange={(e) =>{ handlePieData(e.target.value);}}>
                 {
-                  sortedFormVersions.map((option)=> <option key={option.formId} 
-                  value={option.formId}>{option.version}</option>)
+                  formVersions.map((option)=> <option key={option.formId} 
+                  value={option.formId}>v{option.version}</option>)
                 }
                 <option selected value={"all"}>All</option>
             </select>

--- a/forms-flow-web/src/helper/helper.js
+++ b/forms-flow-web/src/helper/helper.js
@@ -20,20 +20,5 @@ const removeTenantKey = (value, tenantkey) => {
   }
 };
 
-/**
- * 
- * @param {array} data
- * @param {*} Key ? if the data is array of object then you can pass a key 
- * @param {*} order 
- * @returns sorted array
- */
-const sortAlphaNum = ({data, key, order = "asc"})=> {
-  const value1 = order === "asc" ? 1 : -1;
-  const value2 = value1 === 1 ? -1 : 1;
-  if(key){
-   return data.sort((item1, item2) => item1[key] > item2[key] ? value1 : value2);
-  }
-  return data.sort((item1, item2) => item1 > item2 ? value1 : value2);
-};
 
-export { replaceUrl, addTenantkey, removeTenantKey, sortAlphaNum };
+export { replaceUrl, addTenantkey, removeTenantKey };


### PR DESCRIPTION
1. reduced expensive operation on db
2. removed sorting and checking functions on web side
3. taking row number and assign as version of the form by grouping with parent form id in sql query( so here version key is no matter if exist or not in old data)
