### PR TITLE
Dev dependencies changed and Process.env removed from web

### DIFF
--- a/forms-flow-web-root-config/Dockerfile
+++ b/forms-flow-web-root-config/Dockerfile
@@ -29,7 +29,7 @@ COPY package-lock.json /forms-flow-web-root-config/app/package-lock.json
 COPY package.json /forms-flow-web-root-config/app/package.json
 COPY env.sh /forms-flow-web-root-config/app/env.sh
 
-RUN npm ci
+RUN npm ci --production=false
 
 COPY . /forms-flow-web-root-config/app/
 

--- a/forms-flow-web-root-config/Dockerfile
+++ b/forms-flow-web-root-config/Dockerfile
@@ -29,7 +29,7 @@ COPY package-lock.json /forms-flow-web-root-config/app/package-lock.json
 COPY package.json /forms-flow-web-root-config/app/package.json
 COPY env.sh /forms-flow-web-root-config/app/env.sh
 
-RUN npm ci --production=false
+RUN npm ci
 
 COPY . /forms-flow-web-root-config/app/
 

--- a/forms-flow-web-root-config/package.json
+++ b/forms-flow-web-root-config/package.json
@@ -16,24 +16,16 @@
     "@babel/plugin-transform-runtime": "^7.15.0",
     "@babel/preset-env": "^7.15.0",
     "@babel/runtime": "^7.15.3",
-    "copy-webpack-plugin": "^11.0.0",
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",
     "eslint": "^7.32.0",
     "eslint-config-important-stuff": "^1.1.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.1",
-    "html-webpack-plugin": "^5.3.2",
-    "jest": "^27.0.6",
     "jest-cli": "^27.0.6",
     "prettier": "^2.3.2",
     "pretty-quick": "^3.1.1",
-    "serve": "^12.0.0",
-    "webpack": "^5.75.0",
-    "webpack-cli": "^4.8.0",
-    "webpack-config-single-spa": "^5.0.0",
-    "webpack-dev-server": "^4.0.0",
-    "webpack-merge": "^5.8.0"
+    "serve": "^12.0.0"
   },
   "dependencies": {
     "@types/jest": "^27.0.1",
@@ -41,6 +33,14 @@
     "dotenv": "^16.0.3",
     "pubsub-js": "^1.9.4",
     "single-spa": "^5.9.3",
-    "single-spa-layout": "^1.6.0"
+    "single-spa-layout": "^1.6.0",
+    "copy-webpack-plugin": "^11.0.0",
+    "html-webpack-plugin": "^5.3.2",
+    "jest": "^27.0.6",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^4.8.0",
+    "webpack-config-single-spa": "^5.0.0",
+    "webpack-dev-server": "^4.0.0",
+    "webpack-merge": "^5.8.0"
   }
 }

--- a/forms-flow-web/src/featureToogle.js
+++ b/forms-flow-web/src/featureToogle.js
@@ -1,7 +1,6 @@
 function getEnv(env_string) {
   let ENV_BOOLEAN =
     (window._env_ && window._env_[env_string]) ||
-    process.env[env_string] ||
     false;
 
   return ENV_BOOLEAN === "true" || ENV_BOOLEAN === true


### PR DESCRIPTION
## issue
`=> ERROR [forms-flow-web-root-config build-stage 9/9] RUN if [ production == "development" ]; then         npm run build-dev:webpack;     else        3.4s
------
 > [forms-flow-web-root-config build-stage 9/9] RUN if [ production == "development" ]; then         npm run build-dev:webpack;     else         npm run build:webpack;     fi:
#0 1.822
#0 1.822 > @formsflow/root-config@ build:webpack /forms-flow-web-root-config/app
#0 1.822 > webpack --mode=production
#0 1.822
#0 1.827 sh: webpack: not found
#0 1.837 npm ERR! code ELIFECYCLE
#0 1.838 npm ERR! syscall spawn
#0 1.838 npm ERR! file sh
#0 1.839 npm ERR! errno ENOENT
#0 1.844 npm ERR! @formsflow/root-config@ build:webpack: webpack --mode=production
#0 1.844 npm ERR! spawn ENOENT
#0 1.845 npm ERR!
#0 1.845 npm ERR! Failed at the @formsflow/root-config@ build:webpack script.
#0 1.845 npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
#0 1.880
#0 1.880 npm ERR! A complete log of this run can be found in:
#0 1.880 npm ERR!     /root/.npm/_logs/2023-06-26T07_12_06_585Z-debug.log
------
failed to solve: executor failed running [/bin/sh -c if [ $NODE_ENV == "development" ]; then         npm run build-dev:webpack;     else         npm run build:webpack;     fi]: exit code: 1`

## Fixed
1. if NODE_ENV variable is production then npm ci not install the dev dependencies so this error will through