### PR TITLE
Changes in fetch form process mapper details with application id

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/application.py
+++ b/forms-flow-api/src/formsflow_api/models/application.py
@@ -685,7 +685,8 @@ class Application(
                 FormProcessMapper.process_name,
                 FormProcessMapper.process_tenant,
                 FormProcessMapper.task_variable,
-                FormProcessMapper.id.label("mapper_id"),
+                FormProcessMapper.form_type,
+                FormProcessMapper.id,
             )
             .join(cls, FormProcessMapper.id == cls.form_process_mapper_id)
             .filter(Application.id == application_id)

--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -422,9 +422,9 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
             application_id=application_id
         )
         if mapper:
-            if mapper.mapper_id and tenant_key:
+            if mapper.id and tenant_key:
                 FormProcessMapperService.check_tenant_authorization(
-                    mapper_id=mapper.mapper_id, tenant_key=tenant_key
+                    mapper_id=mapper.id, tenant_key=tenant_key
                 )
             mapper_schema = FormProcessMapperSchema()
             return mapper_schema.dump(mapper)


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
Below are changes done while fetching mapper details with application id

- form_type  included 
- mapper_id label removed. So that the id can be reused after being loaded in FormProcessMapperSchema.

Changes are done as a part of the ticket https://aottech.atlassian.net/browse/FWF-2428 since " fetching mapper details with application id" can be reused here to capture the mapper id & form type.