### PR TITLE
port number of forms-flow-data-analysis-api is updated 

### DIFF
--- a/forms-flow-data-analysis-api/Dockerfile
+++ b/forms-flow-data-analysis-api/Dockerfile
@@ -13,7 +13,7 @@ RUN : \
 ADD . /forms-flow-data-analysis-api/app
 RUN pip install .
 
-EXPOSE 5001
+EXPOSE 5000
 RUN python3 -c "from transformers import pipeline; pipeline('sentiment-analysis', model='$MODEL_ID', truncation=True)"
 
 RUN chmod u+x ./entrypoint

--- a/forms-flow-data-analysis-api/docker-compose.yml
+++ b/forms-flow-data-analysis-api/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     links:
       - forms-flow-data-analysis-db
     ports:
-      - '5001:5000'
+      - '6001:5000'
     volumes:
       - ./:/app:rw
     environment:


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG

# Changes

port number of forms-flow-data-analysis-api  is changed in docker-compose file as well as Dockerfile due to the issue with  previous port number . wrong port number given in the Dockerfile . gunicon was running in 5000 and exposed port number in Dockerfile was 5001.  

In the Dockerfile of forms-flow-data-analysis-api made a change that  exposed port is chnaged from 5001 to 5000 as our gunicon is running in 5000

In the docker-compose file host port is chnaged from 5001 to 6001 as 5001 is used by forms-flow-web-api

# How has the change been tested?

Changes tested  locally  and the docker image of data-analysis-api is working with port number 5000 and host port 6001

# Screenshots (if applicable)
![Screenshot 2023-07-18 124907](https://github.com/AOT-Technologies/forms-flow-ai/assets/77142423/89cbada2-b9ad-4d64-ae9e-33e008df93f0)
![Screenshot 2023-07-18 125014](https://github.com/AOT-Technologies/forms-flow-ai/assets/77142423/35487671-b49c-43fb-a450-449f4bef3214)
![Screenshot 2023-07-18 133055](https://github.com/AOT-Technologies/forms-flow-ai/assets/77142423/99699dcc-9a39-4f1c-847a-5ee2084cb512)



# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

If 5000 port is having any conflict with forms-flow-web-api port , then can change the port number to 6001
