### PR TITLE
Fix-pdf-download

### DIFF
--- a/forms-flow-documents/Dockerfile
+++ b/forms-flow-documents/Dockerfile
@@ -10,25 +10,24 @@ WORKDIR /forms-flow-documents/app
 RUN  apt-get update \
   && apt-get install -y gnupg2 \
   && apt-get install -y curl \
+  && apt-get install -y wget \
   && apt-get install -y unzip \
   && apt-get install -y git \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Chrome WebDriver
-RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` && \
-    mkdir -p /opt/chromedriver-$CHROMEDRIVER_VERSION && \
-    curl -sS -o /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
-    unzip -qq /tmp/chromedriver_linux64.zip -d /opt/chromedriver-$CHROMEDRIVER_VERSION && \
+# Install Chrome WebDriver - version 116.0.5845.96
+RUN mkdir -p /opt/chromedriver && \
+    curl -sS -o /tmp/chromedriver_linux64.zip https://d3nrunty6xywgz.cloudfront.net/chromedriver-linux64.zip && \
+    unzip -qq /tmp/chromedriver_linux64.zip -d /opt/chromedriver && \
     rm /tmp/chromedriver_linux64.zip && \
-    chmod +x /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver && \
-    ln -fs /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver /usr/local/bin/chromedriver
+    chmod +x /opt/chromedriver/chromedriver-linux64/chromedriver && \
+    ln -fs /opt/chromedriver/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
 
 # Install Google Chrome
-RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get -yqq update && \
-    apt-get -yqq install google-chrome-stable && \
-    rm -rf /var/lib/apt/lists/*
+RUN wget --no-verbose -O /tmp/chrome.deb https://d3nrunty6xywgz.cloudfront.net/google-chrome-stable_116.0.5845.140-1_amd64.deb &&\
+    apt-get update  && \
+    apt install -y /tmp/chrome.deb &&\
+    rm /tmp/chrome.deb
 
 
 # set display port to avoid crash


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG
https://aottech.atlassian.net/browse/FWF-2531

# Changes
Issue: 
“This version of ChromeDriver only supports Chrome version 114. Current browser version is 116.0.5845.110 with binary path /usr/bin/google-chrome”

Fix
Common version(116) of Chrome driver and Google Chrome are moved to S3. Accessed & installed from there.
