### PR TITLE
Enabled Camunda Authorization Endpoint for Filter Permissions in Migration Script

### DIFF
--- a/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/hooks/rest/AuthorizationRestResource.java
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/hooks/rest/AuthorizationRestResource.java
@@ -1,0 +1,23 @@
+package org.camunda.bpm.extension.hooks.rest;
+
+import org.camunda.bpm.engine.rest.dto.authorization.AuthorizationDto;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+
+@Produces(MediaType.APPLICATION_JSON)
+public interface AuthorizationRestResource extends RestResource{
+
+    String PATH = "/authorization";
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<AuthorizationDto> queryAuthorizations(@Context UriInfo uriInfo,
+                                               @QueryParam("firstResult") Integer firstResult,
+                                               @QueryParam("maxResults") Integer maxResults);
+}

--- a/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/AuthorizationRestResourceImpl.java
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/AuthorizationRestResourceImpl.java
@@ -1,0 +1,26 @@
+package org.camunda.bpm.extension.hooks.rest.impl;
+
+import org.camunda.bpm.engine.rest.AuthorizationRestService;
+import org.camunda.bpm.engine.rest.dto.authorization.AuthorizationDto;
+import org.camunda.bpm.extension.hooks.rest.AuthorizationRestResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+
+public class AuthorizationRestResourceImpl implements AuthorizationRestResource {
+
+    private final AuthorizationRestService restService;
+
+    private static final Logger LOG = LoggerFactory.getLogger(FilterRestResourceImpl.class);
+
+    public AuthorizationRestResourceImpl(AuthorizationRestService restService) {
+        this.restService = restService;
+    }
+
+    @Override
+    public List<AuthorizationDto> queryAuthorizations(UriInfo uriInfo, Integer firstResult, Integer maxResults) {
+        return restService.queryAuthorizations(uriInfo, firstResult, maxResults);
+    }
+}

--- a/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FormsFlowV1RestServiceImpl.java
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/hooks/rest/impl/FormsFlowV1RestServiceImpl.java
@@ -79,4 +79,9 @@ public class FormsFlowV1RestServiceImpl {
         return new TaskFilterRestResourceImpl(serviceFinder.getTaskFilterRestService());
     }
 
+    @Path(AuthorizationRestResource.PATH)
+    public AuthorizationRestResource getAuthorizationRestResource(){
+        return new AuthorizationRestResourceImpl(processEngineService.getAuthorizationRestService());
+    }
+
 }


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-2546

# Changes
Made the camunda authorization endpoint accessible for retrieving filter permissions as part of the filter migration script.

# Screenshots
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/d9d48fbf-3b5a-408e-9506-071ac5189aac)

# Build Success screenshot
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/072a698d-e1eb-45cc-9944-6623d0876860)

