### PR TITLE
Closs Popper on blur

### DIFF
--- a/forms-flow-web/src/components/Form/Steps/PreviewStepper.js
+++ b/forms-flow-web/src/components/Form/Steps/PreviewStepper.js
@@ -374,6 +374,7 @@ const Preview = React.memo(
                         <OverlayTrigger
                           placement="right"
                           trigger="click"
+                          rootClose={true}
                           overlay={(
                             <Popover>
                               <div className="poper">


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/83585487/32c852e6-a3d6-410b-8a44-1d3213a0e23e)

Changes. The popper closes on blur