### PR TITLE
Multi-tenant changes to All Tasks filter

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/filter.py
+++ b/forms-flow-api/src/formsflow_api/models/filter.py
@@ -38,6 +38,14 @@ class Filter(AuditDateTimeMixin, AuditUserMixin, BaseModel, db.Model):
         return query.all()
 
     @classmethod
+    def find_all_filters(cls, tenant: str = None) -> List[Filter]:
+        """Find all filters."""
+        query = cls.query
+        if tenant:
+            query = query.filter(Filter.tenant == tenant)
+        return query.all()
+
+    @classmethod
     def create_filter_from_dict(cls, filter_data: dict) -> Filter:
         """Create Filter."""
         if filter_data:


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes

- In a multi-tenant setup, check for the 'All Tasks' filter. If it's not present for the specific tenant, create it, ensuring the tenant-specific 'All Tasks' filter remains undeleted by the admin.
- Edit/Delete permission to default 'All Tasks' filter in multi-tenant setup
