### PR TITLE
Update insights response with proper message when analytics org is not created for a tenant

### DIFF
--- a/forms-flow-api/src/formsflow_api/constants/__init__.py
+++ b/forms-flow-api/src/formsflow_api/constants/__init__.py
@@ -35,6 +35,10 @@ class BusinessErrorCode(ErrorCodeMixin, Enum):
         "Invalid response received from insights",
         HTTPStatus.BAD_REQUEST,
     )
+    INSIGHTS_NOTFOUND = (
+        "Analytics is not enabled for this tenant",
+        HTTPStatus.BAD_REQUEST,
+    )
     INVALID_BPM_RESPONSE = "Invalid response received from bpm", HTTPStatus.BAD_REQUEST
     BPM_BASE_URL_NOT_SET = "BPM_API_URL not set environment", HTTPStatus.BAD_REQUEST
     MISSING_PAGINATION_PARAMETERS = (

--- a/forms-flow-api/src/formsflow_api/services/external/analytics_api.py
+++ b/forms-flow-api/src/formsflow_api/services/external/analytics_api.py
@@ -32,6 +32,8 @@ class RedashAPIService:  # pylint: disable=too-few-public-methods
             current_app.logger.debug("Response from analytics  %s", response.json())
             if response.ok:
                 return response.json()
+            if response.status_code == 404:
+                raise BusinessException(BusinessErrorCode.INSIGHTS_NOTFOUND)
             raise BusinessException(BusinessErrorCode.INVALID_INSIGHTS_RESPONSE)
         except requests.ConnectionError as e:
             raise BusinessException(ExternalError.INSIGHTS_SERVICE_UNAVAILABLE) from e

--- a/forms-flow-api/tests/unit/api/test_dashboards.py
+++ b/forms-flow-api/tests/unit/api/test_dashboards.py
@@ -36,3 +36,13 @@ def test_get_dashboard_error_details(app, client, session, jwt):
 
     rv = client.get("/dashboards/10000", headers=headers)
     assert rv.json == {"message": "Dashboard - 10000 not accessible"}
+
+
+def test_get_dashboard_error_details_tenant(app, client, session, jwt):
+    """Get dashboards for tenant with analytics not created."""
+    token = get_token(jwt, tenant_key="test-tenant")
+    headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
+
+    rv = client.get("/dashboards", headers=headers)
+    assert rv.status_code == 400
+    assert rv.json["message"] == "Analytics is not enabled for this tenant"


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-2794

# Changes
Updated insights response with a proper message when analytics org is not created for a tenant


# Screenshots 
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/b74437b7-0305-42f0-a60c-14ee6790e456)

![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/fc11cab0-521b-4768-992f-5d1043bac14a)
**Updated  response**
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/58975b89-e266-47b1-99f4-91da540c6954)
