### PR TITLE
Removed HC colors from TaskSearchBarList.scss to add color variables.

### DIFF
--- a/forms-flow-web/src/components/ServiceFlow/list/search/TaskSearchBarListView.scss
+++ b/forms-flow-web/src/components/ServiceFlow/list/search/TaskSearchBarListView.scss
@@ -3,7 +3,7 @@
     .filter-list-view {
         position: absolute;
         z-index: 1000;
-        background-color: white;
+        background-color: var(--color-white);
         top: 31px;;
         min-width: 180px;
     }


### PR DESCRIPTION
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-2573
Issue Type: BUG/ FEATURE

# Changes
Removed HC colors from TaskSearchBarList.scss to add color variables.
