### PR TITLE
Multitenacy default filter fix to 5.3.1 release branch

### DIFF
--- a/forms-flow-api/src/formsflow_api/services/filter.py
+++ b/forms-flow-api/src/formsflow_api/services/filter.py
@@ -59,7 +59,13 @@ class FilterService:
         if current_app.config.get("MULTI_TENANCY_ENABLED"):
             all_filters = Filter.find_all_filters()
             all_tasks_filter = any(
-                (item.name.lower() == "all tasks" and item.status == "active")
+                (
+                    item.name.lower() == "all tasks"
+                    and item.status == "active"
+                    and item.tenant is None
+                    and (not item.roles or item.roles is None)
+                    and (not item.users or item.users is None)
+                )
                 or (item.name.lower() == "all tasks" and item.tenant == tenant_key)
                 for item in all_filters
             )


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-2989

# Changes
Fixed - No default filters are showing on the task page if the 'All task' filter common to all tenants is deleted.