### PR TITLE
update camunda config to support keycloak relative path

### DIFF
--- a/forms-flow-api/src/formsflow_api/services/external/keycloak.py
+++ b/forms-flow-api/src/formsflow_api/services/external/keycloak.py
@@ -43,7 +43,7 @@ class KeycloakAdminAPIService:
         )
         self.base_url = (
             f"{current_app.config.get('KEYCLOAK_URL')}/"
-            f"{current_app.config.get('KEYCLOAK_URL_HTTP_RELATIVE_PATH', 'auth/')}/admin/realms/"
+            f"{current_app.config.get('KEYCLOAK_URL_HTTP_RELATIVE_PATH', 'auth/')}admin/realms/"
             f"{current_app.config.get('KEYCLOAK_URL_REALM')}"
         )
 

--- a/forms-flow-api/src/formsflow_api/services/external/keycloak.py
+++ b/forms-flow-api/src/formsflow_api/services/external/keycloak.py
@@ -42,7 +42,8 @@ class KeycloakAdminAPIService:
             }
         )
         self.base_url = (
-            f"{current_app.config.get('KEYCLOAK_URL')}/auth/admin/realms/"
+            f"{current_app.config.get('KEYCLOAK_URL')}"
+            f"{current_app.config.get('KEYCLOAK_URL_HTTP_RELATIVE_PATH', '/auth')}/admin/realms/"
             f"{current_app.config.get('KEYCLOAK_URL_REALM')}"
         )
 

--- a/forms-flow-api/src/formsflow_api/services/external/keycloak.py
+++ b/forms-flow-api/src/formsflow_api/services/external/keycloak.py
@@ -42,8 +42,8 @@ class KeycloakAdminAPIService:
             }
         )
         self.base_url = (
-            f"{current_app.config.get('KEYCLOAK_URL')}"
-            f"{current_app.config.get('KEYCLOAK_URL_HTTP_RELATIVE_PATH', '/auth')}/admin/realms/"
+            f"{current_app.config.get('KEYCLOAK_URL')}/"
+            f"{current_app.config.get('KEYCLOAK_URL_HTTP_RELATIVE_PATH', 'auth/')}/admin/realms/"
             f"{current_app.config.get('KEYCLOAK_URL_REALM')}"
         )
 

--- a/forms-flow-bpm/forms-flow-bpm-camunda/src/main/resources/application.yaml
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/src/main/resources/application.yaml
@@ -3,6 +3,7 @@ spring.config.import: "optional:file:.env[.properties]"
 
 keycloak.url: ${KEYCLOAK_URL}
 keycloak.url.realm: ${KEYCLOAK_URL_REALM}
+keycloak.url.httpRelativePath: ${KEYCLOAK_URL_HTTP_RELATIVE_PATH:auth/}
 keycloak.clientId: ${KEYCLOAK_CLIENTID}
 keycloak.clientSecret: ${KEYCLOAK_CLIENTSECRET}
 
@@ -102,15 +103,15 @@ spring:
             authorizationGrantType: client_credentials
         provider:
           keycloak:
-            authorization-uri: ${keycloak.url}/auth/realms/${keycloak.url.realm}/protocol/openid-connect/auth
-            token-uri: ${keycloak.url}/auth/realms/${keycloak.url.realm}/protocol/openid-connect/token
-            user-info-uri: ${keycloak.url}/auth/realms/${keycloak.url.realm}/protocol/openid-connect/userinfo
+            authorization-uri: ${keycloak.url}/${keycloak.url.httpRelativePath}realms/${keycloak.url.realm}/protocol/openid-connect/auth
+            token-uri: ${keycloak.url}/${keycloak.url.httpRelativePath}realms/${keycloak.url.realm}/protocol/openid-connect/token
+            user-info-uri: ${keycloak.url}/${keycloak.url.httpRelativePath}realms/${keycloak.url.realm}/protocol/openid-connect/userinfo
             user-name-attribute: preferred_username
-            jwk-set-uri: ${keycloak.url}/auth/realms/${keycloak.url.realm}/protocol/openid-connect/certs
-            issuer-uri: ${keycloak.url}/auth/realms/${keycloak.url.realm}
+            jwk-set-uri: ${keycloak.url}/${keycloak.url.httpRelativePath}realms/${keycloak.url.realm}/protocol/openid-connect/certs
+            issuer-uri: ${keycloak.url}/${keycloak.url.httpRelativePath}realms/${keycloak.url.realm}
       resource-server:
         jwt:
-          issuer-uri: ${keycloak.url}/auth/realms/${keycloak.url.realm}
+          issuer-uri: ${keycloak.url}/${keycloak.url.httpRelativePath}realms/${keycloak.url.realm}
   main:
     allow-bean-definition-overriding: true
 
@@ -137,8 +138,8 @@ plugin.identity.keycloak.rest:
   authorityAttributeName: groupIds
 
 plugin.identity.keycloak:
-  keycloakIssuerUrl: ${keycloak.url}/auth/realms/${keycloak.url.realm}
-  keycloakAdminUrl: ${keycloak.url}/auth/admin/realms/${keycloak.url.realm}
+  keycloakIssuerUrl: ${keycloak.url}/${keycloak.url.httpRelativePath}realms/${keycloak.url.realm}
+  keycloakAdminUrl: ${keycloak.url}/${keycloak.url.httpRelativePath}admin/realms/${keycloak.url.realm}
   clientId: ${keycloak.clientId}
   clientSecret: ${keycloak.clientSecret}
   useEmailAsCamundaUserId: false

--- a/forms-flow-bpm/forms-flow-bpm-camunda/src/test/resources/application.yaml
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/src/test/resources/application.yaml
@@ -20,7 +20,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${keycloak.url.client}/auth/realms/${KEYCLOAK_URL_REALM}
+          issuer-uri: ${keycloak.url.client}/${keycloak.url.httpRelativePath}realms/${KEYCLOAK_URL_REALM}
 
 # disable redis
 spring.data.redis.repositories.enabled: false
@@ -33,8 +33,8 @@ rest.security:
   required-audience: camunda-rest-api
 
 plugin.identity.keycloak:
-  keycloakIssuerUrl: http://localhost:8080/auth/realms/forms-flow-ai
-  keycloakAdminUrl: http://localhost:8080/auth/admin/realms/forms-flow-ai
+  keycloakIssuerUrl: http://localhost:8080/${keycloak.url.httpRelativePath}realms/forms-flow-ai
+  keycloakAdminUrl: http://localhost:8080/${keycloak.url.httpRelativePath}admin/realms/forms-flow-ai
   clientId: forms-flow-bpm
   clientSecret: e3238a38-5e5a-45bb-b4e6-d7eb5855cf3a
   useEmailAsCamundaUserId: false


### PR DESCRIPTION
# Issue Tracking

JIRA: N/A
Issue Type: FEATURE

# Changes
Added a config setting that reads from `KEYCLOAK_URL_HTTP_RELATIVE_PATH` environment variable, with a default of `auth/`, to allow the document path used by keycloak to be overridden. This enables support of newer versions of keycloak that likely do not use the `auth/` document path (unless they are supporting a legacy deployment).

# How has the change been tested?
Manually verified through building and deploying image through our helm deployment

# Build Success screenshot (Till a CICD pipeline is set up)
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/24995887/1836bc06-3ec7-4bed-9c4c-c283df37cd30)
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/24995887/43b11f24-8ef7-461e-8fe5-c92ae67e6b08)

# Notes
There are _many_ hardcoded references to `/auth/` in docker compose files and tests, but none of them will be impacted by this change since the new configuration will default to the hardcoded value. Only folks who choose to override this (currently undocumented) env var in their deployment will see the change. 
