### PR TITLE
Adding AWS deployment access keys

### DIFF
--- a/.github/workflows/forms-flow-api-cd.yml
+++ b/.github/workflows/forms-flow-api-cd.yml
@@ -112,8 +112,8 @@ jobs:
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_DEPLOYMENT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEPLOYMENT_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1  # Change this to your desired region
       - name: Install kubectl
         run: |

--- a/.github/workflows/forms-flow-bpm-cd.yml
+++ b/.github/workflows/forms-flow-bpm-cd.yml
@@ -119,8 +119,8 @@ jobs:
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_DEPLOYMENT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEPLOYMENT_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1  # Change this to your desired region
       - name: Install kubectl
         run: |

--- a/.github/workflows/forms-flow-documents-cd.yml
+++ b/.github/workflows/forms-flow-documents-cd.yml
@@ -120,8 +120,8 @@ jobs:
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_DEPLOYMENT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEPLOYMENT_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1  # Change this to your desired region
       - name: Install kubectl
         run: |

--- a/.github/workflows/forms-flow-root-config-cd.yml
+++ b/.github/workflows/forms-flow-root-config-cd.yml
@@ -120,8 +120,8 @@ jobs:
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_DEPLOYMENT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEPLOYMENT_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1  # Change this to your desired region
       - name: Install kubectl
         run: |

--- a/.github/workflows/qa-deployment.yml
+++ b/.github/workflows/qa-deployment.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_DEPLOYMENT_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DEPLOYMENT_SECRET_ACCESS_KEY }}
           aws-region: ca-central-1  # Change this to your desired region
       - name: Install kubectl
         run: |


### PR DESCRIPTION
# Issue Tracking

# Changes
- S3 and AWS deployment needs to stay separate
- S3 will use the default AWS Access key 
- AWS deployment to use different pair
