### PR TITLE
Adding customRoles to x-jwt-token

### DIFF
--- a/forms-flow-api/src/formsflow_api/resources/formio.py
+++ b/forms-flow-api/src/formsflow_api/resources/formio.py
@@ -120,7 +120,7 @@ class FormioResource(Resource):
             payload: Dict[str, any] = {
                 "external": True,
                 "form": {"_id": _resource_id},
-                "user": {"_id": unique_user_id, "roles": _role_ids},
+                "user": {"_id": unique_user_id, "roles": _role_ids, "customRoles": user.roles},
             }
             if project_id:
                 payload["project"] = {"_id": project_id}

--- a/forms-flow-api/tests/unit/api/test_formio.py
+++ b/forms-flow-api/tests/unit/api/test_formio.py
@@ -32,6 +32,7 @@ def test_formio_roles(app, client, session, jwt, mock_redis_client):
         key=app.config["FORMIO_JWT_SECRET"],
     )
     assert decoded_token["form"]["_id"] == resource_id
+    assert decoded_token["user"]["customRoles"] == ["formsflow-client"]
 
     # Requesting from reviewer role
     token = get_token(jwt, role="formsflow-reviewer")


### PR DESCRIPTION
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-3064

# Changes
- Add `customRoles` to x-jwt-token which contains list of formsflow roles
