### PR TITLE
Adding skip logs option to API and documents for openshift deployment

### DIFF
--- a/forms-flow-api/src/formsflow_api/app.py
+++ b/forms-flow-api/src/formsflow_api/app.py
@@ -53,13 +53,14 @@ def create_app(
     app.logger = flask_logger
     app.logger = logging.getLogger("app")
 
-    register_log_handlers(
-        app,
-        log_file="logs/forms-flow-webapi.log",
-        when=os.getenv("API_LOG_ROTATION_WHEN", "d"),
-        interval=int(os.getenv("API_LOG_ROTATION_INTERVAL", "1")),
-        backupCount=int(os.getenv("API_LOG_BACKUP_COUNT", "7")),
-    )
+    if app.config["CONFIGURE_LOGS"]:
+        register_log_handlers(
+            app,
+            log_file="logs/forms-flow-webapi.log",
+            when=os.getenv("API_LOG_ROTATION_WHEN", "d"),
+            interval=int(os.getenv("API_LOG_ROTATION_INTERVAL", "1")),
+            backupCount=int(os.getenv("API_LOG_BACKUP_COUNT", "7")),
+        )
 
     app.logger.propagate = False
     logging.log.propagate = False

--- a/forms-flow-api/src/formsflow_api/config.py
+++ b/forms-flow-api/src/formsflow_api/config.py
@@ -110,6 +110,9 @@ class _Config:  # pylint: disable=too-few-public-methods
         "FORM_EMBED_JWT_SECRET", "f6a69a42-7f8a-11ed-a1eb-0242ac120002"
     )
 
+    # Configure LOG
+    CONFIGURE_LOGS = str(os.getenv("CONFIGURE_LOGS", default="true")).lower() == "true"
+
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods
     """Development environment configuration."""

--- a/forms-flow-documents/src/formsflow_documents/app.py
+++ b/forms-flow-documents/src/formsflow_documents/app.py
@@ -50,15 +50,18 @@ def create_app(
     )
     app.logger = flask_logger
     app.logger = logging.getLogger("app")
-    register_log_handlers(
-        app,
-        log_file="logs/forms-flow-documents-api.log",
-        when=os.getenv("API_LOG_ROTATION_WHEN", "d"),
-        interval=int(os.getenv("API_LOG_ROTATION_INTERVAL", "1")),
-        backupCount=int(os.getenv("API_LOG_BACKUP_COUNT", "7")),
-    )
-    app.logger.propagate = False
-    logging.log.propagate = False
+
+    if app.config["CONFIGURE_LOGS"]:
+        register_log_handlers(
+            app,
+            log_file="logs/forms-flow-documents-api.log",
+            when=os.getenv("API_LOG_ROTATION_WHEN", "d"),
+            interval=int(os.getenv("API_LOG_ROTATION_INTERVAL", "1")),
+            backupCount=int(os.getenv("API_LOG_BACKUP_COUNT", "7")),
+        )
+        app.logger.propagate = False
+        logging.log.propagate = False
+
     with open("logo.txt") as file:  # pylint: disable=unspecified-encoding
         contents = file.read()
         print(contents)

--- a/forms-flow-documents/src/formsflow_documents/config.py
+++ b/forms-flow-documents/src/formsflow_documents/config.py
@@ -84,6 +84,9 @@ class _Config:  # pylint: disable=too-few-public-methods
         str(os.getenv("MULTI_TENANCY_ENABLED", default="false")).lower() == "true"
     )
 
+    # Configure LOG
+    CONFIGURE_LOGS = str(os.getenv("CONFIGURE_LOGS", default="true")).lower() == "true"
+
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods
     """Development environment configuration."""


### PR DESCRIPTION
# Issue Tracking

# Changes
- Openshift deployment fails for web-api and dcouments-api as the deployment user tries to create a log file and archive folder. Reason is that the user in openshift deployment have only limited access. Adding the flag to skip log file creation if the flag is enabled.
