### PR TITLE
documents-api-fix

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -287,6 +287,7 @@ services:
       API_LOG_ROTATION_WHEN: ${API_LOG_ROTATION_WHEN:-d}
       API_LOG_ROTATION_INTERVAL: ${API_LOG_ROTATION_INTERVAL:-1}
       API_LOG_BACKUP_COUNT: ${API_LOG_BACKUP_COUNT:-7}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
 
     stdin_open: true # -i
     tty: true # -t

--- a/forms-flow-documents/docker-compose.yml
+++ b/forms-flow-documents/docker-compose.yml
@@ -34,8 +34,17 @@ services:
       API_LOG_ROTATION_WHEN: ${API_LOG_ROTATION_WHEN:-d}
       API_LOG_ROTATION_INTERVAL: ${API_LOG_ROTATION_INTERVAL:-1}
       API_LOG_BACKUP_COUNT: ${API_LOG_BACKUP_COUNT:-7}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
     stdin_open: true # -i
     tty: true # -t
+    networks:
+      - forms-flow-webapi-network
+      - redis
+
+  redis:
+    image: "redis:alpine"
+    ports:
+      - "6379:6379"
     networks:
       - forms-flow-webapi-network
 

--- a/forms-flow-documents/requirements.txt
+++ b/forms-flow-documents/requirements.txt
@@ -69,3 +69,4 @@ typing_extensions==4.10.0
 urllib3==2.2.1
 wsproto==1.2.0
 zstandard==0.22.0
+setuptools==69.0.2

--- a/forms-flow-documents/src/formsflow_documents/config.py
+++ b/forms-flow-documents/src/formsflow_documents/config.py
@@ -84,6 +84,9 @@ class _Config:  # pylint: disable=too-few-public-methods
         str(os.getenv("MULTI_TENANCY_ENABLED", default="false")).lower() == "true"
     )
 
+    # REDIS CONFIG
+    REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
     # Configure LOG
     CONFIGURE_LOGS = str(os.getenv("CONFIGURE_LOGS", default="true")).lower() == "true"
 

--- a/forms-flow-documents/tests/conftest.py
+++ b/forms-flow-documents/tests/conftest.py
@@ -1,5 +1,6 @@
 """Common setup and fixtures for the pytest suite used by this service."""
 import pytest
+from unittest.mock import patch
 from formsflow_api_utils.utils import jwt as _jwt
 from formsflow_api_utils.utils.startup import setup_jwt_manager
 
@@ -76,3 +77,29 @@ def docker_compose_files(pytestconfig):
     return [
         os.path.join(str(pytestconfig.rootdir), "tests/docker", "docker-compose.yml")
     ]
+
+
+@pytest.fixture
+def mock_redis_client():
+    """Mock Redis client that will act as a simple key-value store."""
+
+    class MockRedis:
+        """Mock redis class."""
+
+        def __init__(self):
+            self.store = {}
+
+        def set(self, key, value, ex=None):
+            self.store[key] = value
+
+        def get(self, key):
+            return self.store.get(key)
+
+    mock_redis = MockRedis()
+
+    # Patch the RedisManager.get_client to return the mock_redis
+    with patch(
+        "formsflow_api_utils.utils.caching.RedisManager.get_client",
+        return_value=mock_redis,
+    ) as _mock:  # noqa
+        yield mock_redis

--- a/forms-flow-documents/tests/unit/api/test_pdf.py
+++ b/forms-flow-documents/tests/unit/api/test_pdf.py
@@ -7,7 +7,7 @@ from tests.utilities.base_test import get_token
 class TestFormResourceRenderPdf:
     """Test suite for the render endpoint."""
 
-    def test_render_template(self, app, client, jwt):
+    def test_render_template(self, app, client, jwt, mock_redis_client):
         """Assert that API /render when passed with token returns 200 status code."""
         with app.app_context():
             token = get_token(jwt)

--- a/forms-flow-documents/tests/unit/services/test_pdf.py
+++ b/forms-flow-documents/tests/unit/services/test_pdf.py
@@ -10,7 +10,7 @@ class TestPDFService:
 
     template = get_test_template()
 
-    def test_get_render_data_without_template_and_template_variable(self, app):
+    def test_get_render_data_without_template_and_template_variable(self, app, mock_redis_client):
         """Test get_render_data method for the request without template and template variable."""
         with app.app_context():
             service = PDFService(form_id="1234", submission_id="1234567")
@@ -45,7 +45,7 @@ class TestPDFService:
             service.delete_template(template_name)
             service.delete_template(template_var_name)
 
-    def test_get_render_data_with_template_and_without_template_variable(self, app):
+    def test_get_render_data_with_template_and_without_template_variable(self, app, mock_redis_client):
         """Test get_render_data method for the request with template and without template variable."""
         with app.app_context():
             service = PDFService(form_id="1234", submission_id="1234567")


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-3163

# Changes
Issue
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/c4bdb857-68d3-466c-af52-916dfc1dc1ac)
Fix - Added setuptools pkg which is missed during the previous merge.

Issue
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/2452154a-51d4-48d7-9c44-015063a5e5f7)
- documents API requires formio token to connect formio which is saved in redis cache which is missing in documents api

![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/4263f202-9e57-4cff-aefb-f5e1650c3f1e)
