### PR TITLE
Added Form Id in Task Filter 

### DIFF
--- a/forms-flow-api/src/formsflow_api/services/application.py
+++ b/forms-flow-api/src/formsflow_api/services/application.py
@@ -59,6 +59,7 @@ class ApplicationService:  # pylint: disable=too-many-public-methods
                 "submitterName": {"value": application.created_by},
                 "submissionDate": {"value": str(application.created)},
                 "tenantKey": {"value": mapper.tenant},
+                "formId": {"value": mapper.form_id},
             }
         }
 

--- a/forms-flow-web/src/components/Form/Steps/WorkFlow.js
+++ b/forms-flow-web/src/components/Form/Steps/WorkFlow.js
@@ -14,6 +14,7 @@ import ViewAndEditTaskvariable from "./ViewAndEditTaskvariable";
 import { useTranslation } from "react-i18next";
 import { listProcess } from "../../../apiManager/services/formatterService";
 import { DEFAULT_WORKFLOW } from "../../../constants/taskConstants";
+import { filterSelectOptionByLabel } from "../../../helper/helper";
 
 const WorkFlow = React.memo(
   ({
@@ -137,6 +138,7 @@ const WorkFlow = React.memo(
       updateTaskvariableToProcessData(updatedData);
     };
 
+
     useEffect(() => {
       if (!workflow) {
         setModified(true);
@@ -228,6 +230,7 @@ const WorkFlow = React.memo(
                 onChange={(selectedOption) => handleListChange(selectedOption)}
                 isDisabled={disableWorkflowAssociation}
                 inputId="select-workflow"
+                filterOption={filterSelectOptionByLabel}
                 getOptionLabel={(option) => (
                   <span data-testid={`form-workflow-option-${option.value}`}>
                     {option.label}

--- a/forms-flow-web/src/components/ServiceFlow/list/ServiceTaskList.js
+++ b/forms-flow-web/src/components/ServiceFlow/list/ServiceTaskList.js
@@ -19,6 +19,7 @@ import { MAX_RESULTS } from "../constants/taskConstants";
 import { getFirstResultIndex } from "../../../apiManager/services/taskSearchParamsFormatterService";
 import TaskVariable from "./TaskVariable";
 import { MULTITENANCY_ENABLED } from "../../../constants/constants";
+import _ from "lodash";
 const ServiceFlowTaskList = React.memo((props) => {
   const {expandedTasks,setExpandedTasks} = props;
   const { t } = useTranslation();
@@ -42,12 +43,16 @@ const ServiceFlowTaskList = React.memo((props) => {
 
   useEffect(() => {
     if (selectedFilter?.id) {
- 
+        const reqDataProcessVariables = reqData?.criteria?.processVariables || [];
+        const selectedProcessVariables =  selectedFilter?.criteria?.processVariables || [];
+         
         const selectedBPMFilterParams = {
           ...selectedFilter,
           criteria: {
             ...selectedFilter?.criteria,
-            ...reqData?.criteria
+            ...reqData?.criteria,
+            processVariables:_.isEqual(reqDataProcessVariables, selectedProcessVariables) 
+            ? selectedProcessVariables : [...reqDataProcessVariables,...selectedProcessVariables]
           }
         };
       dispatch(setBPMTaskLoader(true));

--- a/forms-flow-web/src/components/ServiceFlow/list/sort/CreateNewFilter.js
+++ b/forms-flow-web/src/components/ServiceFlow/list/sort/CreateNewFilter.js
@@ -53,6 +53,7 @@ import {
   resetFormProcessData,
 } from "../../../../apiManager/services/processServices";
 import { fetchUserList } from "../../../../apiManager/services/bpmTaskServices";
+import { filterSelectOptionByLabel } from "../../../../helper/helper";
 
 const initialValueOfTaskAttribute = {
   applicationId: true,
@@ -691,6 +692,7 @@ export default function CreateNewFilterDrawer({
             onChange={(selectedOption) => {
               setDefinitionKeyId(selectedOption?.label);
             }}
+            filterOption={filterSelectOptionByLabel}
             inputId="select-workflow"
             getOptionLabel={(option) => (
               <span data-testid={`form-workflow-option-${option.value}`}>

--- a/forms-flow-web/src/components/ServiceFlow/list/sort/CreateNewFilter.js
+++ b/forms-flow-web/src/components/ServiceFlow/list/sort/CreateNewFilter.js
@@ -418,16 +418,19 @@ export default function CreateNewFilterDrawer({
      * If a form is selected, set the formId property in the data object
      * to the id of the selected form.
      */
-    if (selectedForm) {
-      data.properties.formId = selectedForm;
-    }
-
+    
+    
     // Remove empty keys inside criteria
     const cleanedCriteria = omitBy(
       data.criteria,
       (value) => value === undefined || value === "" || value === null
-    );
-    data.criteria = cleanedCriteria;
+      );
+      data.criteria = cleanedCriteria;
+      
+      if (selectedForm) {
+        data.properties.formId = selectedForm;
+        data.criteria.processVariables = [{name: "formId", operator: "eq", value: selectedForm}];
+      }
 
     const submitFunction = selectedFilterData
       ? editFilters(data, selectedFilterData?.id)

--- a/forms-flow-web/src/helper/helper.js
+++ b/forms-flow-web/src/helper/helper.js
@@ -48,4 +48,11 @@ const renderPage = (formStatus, processLoadError) => {
     );
   } 
 };
-export { replaceUrl, addTenantkey, removeTenantKey, textTruncate, renderPage };
+
+const filterSelectOptionByLabel = (option, searchText) => {
+  return option.data.label.toLowerCase().includes(searchText.toLowerCase());
+};
+
+
+export { replaceUrl, addTenantkey, removeTenantKey, textTruncate, renderPage, 
+  filterSelectOptionByLabel};


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
If a form is selected while creating or editing a task filter, the form ID will also be included in the task filter. Subsequently, when the filter is used to list tasks, they will be listed against the associated form ID by default.

Added this condition 

    if (slectedFormid is there) {
        data.properties.formId = selectedForm;
        data.criteria.processVariables = [{name: "formId", operator: "eq", value: selectedForm}];
      }

