### PR TITLE
[FWF-3153] Fix for camunda logout issue

### DIFF
--- a/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/keycloak/sso/KeycloakLogoutHandler.java
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/keycloak/sso/KeycloakLogoutHandler.java
@@ -33,6 +33,10 @@ public class KeycloakLogoutHandler implements LogoutSuccessHandler {
 	/** Keycloak's logout URI. */
 	private String oauth2UserLogoutUri;
 
+	/** Keycloak's Client ID. */
+	@Value("${keycloak.clientId}")
+	private String clientId;
+
 	/**
 	 * Default constructor.
 	 * @param oauth2UserAuthorizationUri configured keycloak authorization URI
@@ -53,10 +57,10 @@ public class KeycloakLogoutHandler implements LogoutSuccessHandler {
 
 		if (!ObjectUtils.isEmpty(oauth2UserLogoutUri)) {
 			// Calculate redirect URI for Keycloak, something like http://<host:port>/camunda/login
-			String requestUrl = request.getRequestURL().toString();
-			String redirectUri = requestUrl.substring(0, requestUrl.indexOf("/app"));
+			var requestUrl = request.getRequestURL().toString();
+			var redirectUri = requestUrl.substring(0, requestUrl.indexOf("/app"));
 			// Complete logout URL
-			String logoutUrl = oauth2UserLogoutUri + "?redirect_uri=" + redirectUri;
+			var logoutUrl = oauth2UserLogoutUri + "?post_logout_redirect_uri=" + redirectUri + "&client_id=" + clientId;
 			Cookie[] cookies = request.getCookies();
 			for (Cookie cookie : cookies) {
 				LOG.debug("-------cookie---------->"+cookie.getName());


### PR DESCRIPTION

# Issue Tracking

JIRA: 
Issue Type: BUG
https://aottech.atlassian.net/browse/FWF-3153

# Changes
* [Fix for camunda logout issue](https://github.com/AOT-Technologies/forms-flow-ai/commit/f18b0df170444649c94eb4e79f66782135c2870f)
* Change in KeycloakLogoutHandler.class

# How has the change been tested?


# Screenshots
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/85665463/f8503906-34d8-4f5a-a2c3-3fa918ae3814)

![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/85665463/9f2e0a10-c42f-4ccd-aefb-8286f2fe9a0b)



# Build Success screenshot (Till a CICD pipeline is set up)

# Notes
According to the [version 18 release note](https://www.keycloak.org/2022/04/keycloak-1800-released). Keycloak does not support logout with redirect_uri anymore. you need to include post_logout_redirect_uri and id_token_hint as parameters.

