### PR TITLE
[Jira-3147] forms-flow-bpm vulnerability issue fix

### DIFF
--- a/forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
@@ -331,7 +331,7 @@
         <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js-scriptengine</artifactId>
-            <version>23.0.0</version>
+            <version>23.1.0</version>
         </dependency>
 
         <dependency>

--- a/forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
@@ -31,12 +31,12 @@
         <version.camunda>7.20.0</version.camunda><!-- 7.18.0 - 7.20.0 -->
         <version.camundaConnect>1.5.4</version.camundaConnect><!-- 1.5.4 -->
         <version.camundaMail>1.5.0</version.camundaMail><!-- 1.5.0 -->
-        <version.springBoot>3.1.5</version.springBoot><!-- 2.7.12 - 3.1.5 -->
+        <version.springBoot>3.1.10</version.springBoot><!-- 3.1.5 - 3.1.10 -->
         <version.springSecurityOauth2>2.6.8</version.springSecurityOauth2><!--
 			2.6.7 - 2.6.8 -->
         <version.jackson>2.15.0</version.jackson>
         <version.commonsFileUpload>1.5</version.commonsFileUpload>
-        <version.snakeyaml>2.0</version.snakeyaml>
+        <version.snakeyaml>2.2</version.snakeyaml>
     </properties>
 
     <dependencyManagement>
@@ -82,6 +82,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -207,7 +213,7 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <!--version>9.4-1205-jdbc41</version -->
-            <version>42.4.3</version>
+            <version>42.7.2</version>
         </dependency>
 
         <dependency>
@@ -264,7 +270,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>3.0.19</version>
+            <version>3.0.21</version>
             <type>pom</type>
         </dependency>
 
@@ -325,13 +331,13 @@
         <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js-scriptengine</artifactId>
-            <version>22.3.3</version>
+            <version>23.0.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js</artifactId>
-            <version>22.3.3</version>
+            <version>23.0.0</version>
         </dependency>
 
         <dependency>

--- a/forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
@@ -331,7 +331,7 @@
         <dependency>
             <groupId>org.graalvm.js</groupId>
             <artifactId>js-scriptengine</artifactId>
-            <version>23.1.0</version>
+            <version>23.0.0</version>
         </dependency>
 
         <dependency>

--- a/forms-flow-bpm/pom.xml
+++ b/forms-flow-bpm/pom.xml
@@ -310,7 +310,7 @@
 				<dependency>
 					<groupId>org.graalvm.js</groupId>
 					<artifactId>js-scriptengine</artifactId>
-					<version>23.0.0</version>
+					<version>23.1.0</version>
 				</dependency>
 
 				<dependency>

--- a/forms-flow-bpm/pom.xml
+++ b/forms-flow-bpm/pom.xml
@@ -310,7 +310,7 @@
 				<dependency>
 					<groupId>org.graalvm.js</groupId>
 					<artifactId>js-scriptengine</artifactId>
-					<version>23.1.0</version>
+					<version>23.0.0</version>
 				</dependency>
 
 				<dependency>

--- a/forms-flow-bpm/pom.xml
+++ b/forms-flow-bpm/pom.xml
@@ -26,12 +26,12 @@
 		<version.camunda>7.20.0</version.camunda><!-- 7.18.0 - 7.20.0 -->
 		<version.camundaConnect>1.5.4</version.camundaConnect><!-- 1.5.4 -->
 		<version.camundaMail>1.5.0</version.camundaMail><!-- 1.5.0 -->
-		<version.springBoot>3.1.5</version.springBoot><!-- 2.7.12 - 3.1.5 -->
+		<version.springBoot>3.1.10</version.springBoot><!-- 3.1.5 - 3.1.10 -->
 		<version.springSecurityOauth2>2.6.8</version.springSecurityOauth2><!--
 			2.6.7 - 2.6.8 -->
 		<version.jackson>2.15.0</version.jackson>
 		<version.commonsFileUpload>1.5</version.commonsFileUpload>
-		<version.snakeyaml>2.0</version.snakeyaml>
+		<version.snakeyaml>2.2</version.snakeyaml>
 	</properties>
 
 	<profiles>
@@ -192,7 +192,7 @@
 					<groupId>org.postgresql</groupId>
 					<artifactId>postgresql</artifactId>
 					<!--version>9.4-1205-jdbc41</version -->
-					<version>42.4.3</version>
+					<version>42.7.2</version>
 				</dependency>
 
 
@@ -250,7 +250,7 @@
 				<dependency>
 					<groupId>org.codehaus.groovy</groupId>
 					<artifactId>groovy-all</artifactId>
-					<version>3.0.19</version>
+					<version>3.0.21</version>
 					<type>pom</type>
 				</dependency>
 
@@ -310,13 +310,13 @@
 				<dependency>
 					<groupId>org.graalvm.js</groupId>
 					<artifactId>js-scriptengine</artifactId>
-					<version>22.3.3</version>
+					<version>23.0.0</version>
 				</dependency>
 
 				<dependency>
 					<groupId>org.graalvm.js</groupId>
 					<artifactId>js</artifactId>
-					<version>22.3.3</version>
+					<version>23.0.0</version>
 				</dependency>
 
 				<dependency>


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-3147

# Changes
- Changes to the following files to upgrade the vulnerable dependencies to a fixed version:
    - forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
    
-  Upgrades
    - springboot:3.1.5->3.1.10
    - snakeyaml:2.0->2.2
    - postgresql:42.4.3->42.7.2
    - groovy:3.0.19->3.0.21
    - graalvm->22.3.3->23.0.0
-  Screenshots
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/85665463/b6a9dbaf-ff81-4d7a-8c23-449d6ce6d9cd)

# How has the change been tested?


# Screenshots (if applicable)


# Build Success screenshot (Till a CICD pipeline is set up)
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/85665463/dced06a3-38e6-44f8-a0dd-19b24051baa6)



# Notes

