### PR TITLE
Fix: Task variable label is not getting updated in task filter 

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/filter.py
+++ b/forms-flow-api/src/formsflow_api/models/filter.py
@@ -164,3 +164,16 @@ class Filter(AuditDateTimeMixin, AuditUserMixin, BaseModel, db.Model):
             filter_info,
         )
         self.commit()
+
+    @classmethod
+    def find_all_active_filters_formid(
+        cls, form_id, tenant: str = None
+    ) -> List[Filter]:
+        """Find all active filters with specific form id."""
+        query = cls.query.filter(
+            Filter.status == str(FilterStatus.ACTIVE.value),
+            Filter.properties.op("->>")("formId") == form_id,
+        )
+        if tenant:
+            query = query.filter(Filter.tenant == tenant)
+        return query.all() or []

--- a/forms-flow-api/src/formsflow_api/resources/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/resources/form_process_mapper.py
@@ -20,6 +20,7 @@ from formsflow_api.schemas import (
 )
 from formsflow_api.services import (
     ApplicationService,
+    FilterService,
     FormHistoryService,
     FormProcessMapperService,
 )
@@ -356,6 +357,9 @@ class FormResourceById(Resource):
         application_json = request.get_json()
 
         if "taskVariable" in application_json:
+            FilterService.update_filter_variables(
+                application_json.get("taskVariable"), application_json.get("formId")
+            )
             application_json["taskVariable"] = json.dumps(
                 application_json.get("taskVariable")
             )


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
Fix: The task variable label is not getting updated in the task filter  when it's updated in the form mapper

update_filter_variables function - updates the filter variables for all active filters associated with a given form id. It maps the task variable keys to their corresponding labels, and then updates the labels in the filter variables. It also removes any filter variables that are not found in the task variables, except for the default variables "applicationId" and "formName".



# Screenshots 
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/f8f16c67-f9e9-4604-81ad-022bd7b5f57a)

![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/6ea10756-8264-4c55-8dfa-1f20211c01ab)
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/62a04b2c-04c0-4da2-9565-44dec17f7705)
