### PR TITLE
Added realm-admin role to service-account user

### DIFF
--- a/forms-flow-idm/keycloak/imports/formsflow-ai-realm.json
+++ b/forms-flow-idm/keycloak/imports/formsflow-ai-realm.json
@@ -621,7 +621,7 @@
     "requiredActions" : [ ],
     "realmRoles" : [ "uma_authorization", "offline_access" ],
     "clientRoles" : {
-      "realm-management" : [ "manage-users", "query-users", "query-groups", "view-users" , "manage-clients"],
+      "realm-management" : [ "manage-users", "query-users", "query-groups", "view-users" , "manage-clients", "realm-admin"],
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,

--- a/forms-flow-idm/realm-exports/Group based auth.json
+++ b/forms-flow-idm/realm-exports/Group based auth.json
@@ -642,7 +642,7 @@
     "requiredActions" : [ ],
     "realmRoles" : [ "uma_authorization", "offline_access" ],
     "clientRoles" : {
-      "realm-management" : [ "manage-users", "query-users", "query-groups", "view-users" , "query-clients"],
+      "realm-management" : [ "manage-users", "query-users", "query-groups", "view-users" , "query-clients", "realm-admin"],
       "account" : [ "view-profile", "manage-account" ]
     },
     "notBefore" : 0,


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
This change adds the realm-admin role to the service account user in the group-based environment. The realm-admin role is required to use the /auth/admin/realms/{realm}/partialImport endpoint in Keycloak, which is necessary for creating a separate Keycloak client for Workato integrations.

Without realm-admin role partialImport endpoint throws error
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/d2a2aced-ae2c-4527-b19a-b50daca4b7d1)
