### PR TITLE
[Bugfix]: FWF-3309 Added roles to driver localstorage

### DIFF
--- a/.github/workflows/forms-flow-documents-ci.yml
+++ b/.github/workflows/forms-flow-documents-ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.12.3]
+        python-version: [3.12.4]
 
     steps:
       - uses: actions/checkout@v2

--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/pdf.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/pdf.py
@@ -73,6 +73,9 @@ def get_pdf_from_html(path, chromedriver=None, p_options=None, args=None):
         "role": token_info.get("roles", None) or token_info.get(
             "role", None
         ),
+        "roles": token_info.get("roles", None) or token_info.get(
+            "role", None
+        ),
         "name": token_info.get("name", None),
         "groups": token_info.get("groups", None),
         "preferred_username": token_info.get("preferred_username", None),

--- a/forms-flow-documents/requirements.txt
+++ b/forms-flow-documents/requirements.txt
@@ -27,7 +27,7 @@ ecdsa==0.18.0
 flask-jwt-oidc==0.3.0
 flask-marshmallow==1.2.1
 flask-restx==1.3.0
-formsflow_api_utils @ git+https://github.com/auslin-aot/forms-flow-ai.git@feature/FWF-3257-export-pdf-bundle#subdirectory=forms-flow-api-utils
+formsflow_api_utils @ git+https://github.com/auslin-aot/forms-flow-ai.git@bugfix/FWF-3309-Add-roles-to-localstorage#subdirectory=forms-flow-api-utils
 gunicorn==21.2.0
 h11==0.14.0
 h2==4.1.0

--- a/forms-flow-documents/requirements/prod.txt
+++ b/forms-flow-documents/requirements/prod.txt
@@ -17,4 +17,4 @@ PyJWT
 selenium
 selenium-wire
 nested-lookup
-git+https://github.com/auslin-aot/forms-flow-ai.git@feature/FWF-3257-export-pdf-bundle#egg=formsflow_api_utils&subdirectory=forms-flow-api-utils
+git+https://github.com/auslin-aot/forms-flow-ai.git@bugfix/FWF-3309-Add-roles-to-localstorage#egg=formsflow_api_utils&subdirectory=forms-flow-api-utils


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-3309

# Changes
In a multitenancy setup, roles are stored in UserDetails, which are used to control the hiding and revealing of panels in the form. These roles were missed in the previous PR, so they are now being added to the Chrome Driver's local storage.

![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/76f9aea4-a5b5-4560-8b0a-379eeb76dae5)


# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request