### PR TITLE
🐛 FWF-3222: [Bugfix] Handle service-account in application history

### DIFF
--- a/forms-flow-api/src/formsflow_api/models/application_history.py
+++ b/forms-flow-api/src/formsflow_api/models/application_history.py
@@ -55,3 +55,8 @@ class ApplicationHistory(ApplicationAuditDateTimeMixin, BaseModel, db.Model):
                 cls.submitted_by,
             )
         )
+
+    @classmethod
+    def get_application_history_by_id(cls, application_id: int):
+        """Find application history by id."""
+        return cls.query.filter(cls.application_id == application_id).first()

--- a/forms-flow-api/src/formsflow_api/resources/application_history.py
+++ b/forms-flow-api/src/formsflow_api/resources/application_history.py
@@ -89,12 +89,11 @@ class ApplicationHistoryResource(Resource):
         """Post a new history entry using the request body."""
         application_history_json = request.get_json()
 
-        # try:
         application_history_schema = ApplicationHistorySchema()
         dict_data = application_history_schema.load(application_history_json)
         dict_data["application_id"] = application_id
         application_history = ApplicationHistoryService.create_application_history(
-            data=dict_data
+            data=dict_data, application_id=application_id
         )
 
         response, status = (

--- a/forms-flow-api/src/formsflow_api/services/application_history.py
+++ b/forms-flow-api/src/formsflow_api/services/application_history.py
@@ -3,7 +3,7 @@
 from flask import current_app
 from formsflow_api_utils.utils import get_form_and_submission_id_from_form_url
 
-from formsflow_api.models import ApplicationHistory
+from formsflow_api.models import Application, ApplicationHistory
 from formsflow_api.schemas import ApplicationHistorySchema
 
 
@@ -11,8 +11,18 @@ class ApplicationHistoryService:
     """This class manages application service."""
 
     @staticmethod
-    def create_application_history(data):
+    def create_application_history(data, application_id):
         """Create new application history."""
+        # Replace service-account with application creator in initial history.
+        if data.get("submitted_by") and data.get("submitted_by").startswith(
+            "service-account"
+        ):
+            application_history = ApplicationHistory.get_application_history_by_id(
+                application_id
+            )
+            if not application_history:
+                application = Application.find_by_id(application_id)
+                data["submitted_by"] = application.created_by
         (form_id, submission_id) = get_form_and_submission_id_from_form_url(
             data["form_url"]
         )

--- a/forms-flow-api/tests/unit/services/test_application_history.py
+++ b/forms-flow-api/tests/unit/services/test_application_history.py
@@ -13,7 +13,7 @@ def test_create_application_history(app, client, session):
     }
     payload["application_id"] = 1222  # sample value
     application_history = application_history_service.create_application_history(
-        data=payload
+        data=payload, application_id=1222
     )
     assert application_history.application_id == 1222
     assert application_history.application_status == "Pending"


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-3222

# Changes
Handled the submittedBy "service-account" entry in the initial application history by replacing it with the application creator.

# Screenshots 
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/886d48c3-7321-45b6-9aba-def49397b62a)
![image](https://github.com/AOT-Technologies/forms-flow-ai/assets/99173163/9368344a-7183-4d80-8348-493c90b905df)

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request