### PR TITLE
Reverting Camunda to 7.20.0 to avoid warning

### DIFF
--- a/forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/pom.xml
@@ -28,7 +28,7 @@
 
         <!-- versions -->
         <version.camundaKeycloak>7.21.5</version.camundaKeycloak>
-        <version.camunda>7.21.0</version.camunda><!-- 7.18.0 - 7.20.0 -->
+        <version.camunda>7.20.0</version.camunda><!-- 7.18.0 - 7.20.0 -->
         <version.camundaConnect>1.5.4</version.camundaConnect><!-- 1.5.4 -->
         <version.camundaMail>1.5.0</version.camundaMail><!-- 1.5.0 -->
         <version.springBoot>3.1.10</version.springBoot><!-- 3.1.5 - 3.1.10 -->

--- a/forms-flow-bpm/pom.xml
+++ b/forms-flow-bpm/pom.xml
@@ -23,7 +23,7 @@
 
 		<!-- versions -->
 		<version.camundaKeycloak>7.21.5</version.camundaKeycloak>
-		<version.camunda>7.21.0</version.camunda><!-- 7.18.0 - 7.20.0 -->
+		<version.camunda>7.20.0</version.camunda><!-- 7.18.0 - 7.20.0 -->
 		<version.camundaConnect>1.5.4</version.camundaConnect><!-- 1.5.4 -->
 		<version.camundaMail>1.5.0</version.camundaMail><!-- 1.5.0 -->
 		<version.springBoot>3.1.10</version.springBoot><!-- 3.1.5 - 3.1.10 -->


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
7.21.0 Cockpit shows warning to users to upgrade to premium. Downgrading to 7.20.0.
<img width="1727" alt="Screenshot 2024-08-21 at 2 50 58 PM" src="https://github.com/user-attachments/assets/d4527d98-23e1-4ba3-b89f-63b391f40f5d">
