### PR TITLE
[Bugfix] Version of form showing as null fixed on saving layout after making update to settings modal

### DIFF
--- a/forms-flow-web/src/components/Form/Item/Edit.js
+++ b/forms-flow-web/src/components/Form/Item/Edit.js
@@ -324,6 +324,8 @@ const Edit = React.memo(() => {
       workflowChanged: false,
       statusChanged: false,
       resourceId: form._id,
+      majorVersion:processListData.majorVersion,
+      minorVersion:processListData.minorVersion,
     };
 
     const authorizations = {


### PR DESCRIPTION
[Bugfix] Version of form showing as null fixed on saving layout after making update to settings modal

# Issue Tracking

JIRA: 
Issue Type: BUG

# Changes


# Screenshots (if applicable)
Before : 
<img width="1007" alt="Screenshot 2024-10-15 at 1 28 54 PM" src="https://github.com/user-attachments/assets/176522d7-67f9-4419-90d8-32e5b5c0c5bb">


After : 
<img width="771" alt="Screenshot 2024-10-15 at 1 40 30 PM" src="https://github.com/user-attachments/assets/0e770129-2e11-4a8d-bd8e-f26bc0f7a5f3">

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request