### PR TITLE
FWF-4077: [Bugfix] Allow hyphen in form title, path & name

### DIFF
--- a/forms-flow-api/src/formsflow_api/services/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/services/form_process_mapper.py
@@ -738,15 +738,15 @@ class FormProcessMapperService:  # pylint: disable=too-many-public-methods
     @classmethod
     def validate_title_name_path(cls, title: str, path: str, name: str):
         """Validates the title, path, and name fields."""
-        title_pattern = r"(?=.*[A-Za-z])[A-Za-z0-9 ]+"
-        path_name = r"(?=.*[A-Za-z])[A-Za-z0-9]+"
+        title_pattern = r"(?=.*[A-Za-z])^[A-Za-z0-9 ]+(-{1,}[A-Za-z0-9 ]+)*$"
+        path_name = r"(?=.*[A-Za-z])^[A-Za-z0-9]+(-{1,}[A-Za-z0-9]+)*$"
 
         invalid_fields = []
 
         error_messages = {
-            "title": "Title: Only contain alphanumeric characters and spaces, and must include at least one letter.",
-            "path": "Path: Only contain alphanumeric characters, no spaces, and must include at least one letter.",
-            "name": "Name: Only contain alphanumeric characters, no spaces, and must include at least one letter.",
+            "title": "Title: Only contain alphanumeric characters, hyphens(not at the start or end), spaces, and must include at least one letter.",
+            "path": "Path: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces, and must include at least one letter.",
+            "name": "Name: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces, and must include at least one letter.",
         }
 
         # Validate title

--- a/forms-flow-api/src/formsflow_api/services/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/services/form_process_mapper.py
@@ -744,9 +744,12 @@ class FormProcessMapperService:  # pylint: disable=too-many-public-methods
         invalid_fields = []
 
         error_messages = {
-            "title": "Title: Only contain alphanumeric characters, hyphens(not at the start or end), spaces, and must include at least one letter.",
-            "path": "Path: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces, and must include at least one letter.",
-            "name": "Name: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces, and must include at least one letter.",
+            "title": "Title: Only contain alphanumeric characters, hyphens(not at the start or end), spaces,"
+            "and must include at least one letter.",
+            "path": "Path: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,"
+            "and must include at least one letter.",
+            "name": "Name: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,"
+            "and must include at least one letter.",
         }
 
         # Validate title
@@ -793,6 +796,7 @@ class FormProcessMapperService:  # pylint: disable=too-many-public-methods
         name = request.args.get("name")
         path = request.args.get("path")
         form_id = request.args.get("id")
+        current_app.logger.info(f"Title:{title}, Name:{name}, Path:{path}")
 
         # Check if at least one query parameter is provided
         if not (title or name or path):

--- a/forms-flow-api/tests/unit/api/test_form_process_mapper.py
+++ b/forms-flow-api/tests/unit/api/test_form_process_mapper.py
@@ -573,7 +573,7 @@ def test_form_name_invalid_form_title(app, client, session, jwt, mock_redis_clie
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Title: Only contain alphanumeric characters and spaces, and must include at least one letter."
+        == "Title: Only contain alphanumeric characters, hyphens(not at the start or end), spaces,and must include at least one letter."
     )
     # With special characters
     response = client.get("/form/validate?title=$$", headers=headers)
@@ -581,14 +581,14 @@ def test_form_name_invalid_form_title(app, client, session, jwt, mock_redis_clie
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Title: Only contain alphanumeric characters and spaces, and must include at least one letter."
+        == "Title: Only contain alphanumeric characters, hyphens(not at the start or end), spaces,and must include at least one letter."
     )
     response = client.get("/form/validate?title=1234$@@#test", headers=headers)
     assert response.status_code == 400
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Title: Only contain alphanumeric characters and spaces, and must include at least one letter."
+        == "Title: Only contain alphanumeric characters, hyphens(not at the start or end), spaces,and must include at least one letter."
     )
 
 
@@ -602,7 +602,7 @@ def test_form_name_invalid_form_name(app, client, session, jwt, mock_redis_clien
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Name: Only contain alphanumeric characters, no spaces, and must include at least one letter."
+        == "Name: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."
     )
     # With special characters
     response = client.get("/form/validate?name=1234", headers=headers)
@@ -610,7 +610,7 @@ def test_form_name_invalid_form_name(app, client, session, jwt, mock_redis_clien
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Name: Only contain alphanumeric characters, no spaces, and must include at least one letter."
+        == "Name: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."
     )
     # With spaces
     response = client.get("/form/validate?name=test form", headers=headers)
@@ -618,7 +618,7 @@ def test_form_name_invalid_form_name(app, client, session, jwt, mock_redis_clien
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Name: Only contain alphanumeric characters, no spaces, and must include at least one letter."
+        == "Name: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."
     )
 
 
@@ -632,7 +632,7 @@ def test_form_name_invalid_form_path(app, client, session, jwt, mock_redis_clien
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Path: Only contain alphanumeric characters, no spaces, and must include at least one letter."
+        == "Path: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."
     )
     # With special characters
     response = client.get("/form/validate?path=1234", headers=headers)
@@ -640,7 +640,7 @@ def test_form_name_invalid_form_path(app, client, session, jwt, mock_redis_clien
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Path: Only contain alphanumeric characters, no spaces, and must include at least one letter."
+        == "Path: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."
     )
     # With spaces
     response = client.get("/form/validate?path=test form", headers=headers)
@@ -648,7 +648,7 @@ def test_form_name_invalid_form_path(app, client, session, jwt, mock_redis_clien
     assert response.json is not None
     assert (
         response.json["message"]
-        == "Path: Only contain alphanumeric characters, no spaces, and must include at least one letter."
+        == "Path: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."
     )
 
 
@@ -667,7 +667,7 @@ def test_form_name_invalid_form_name_title_path(
     assert response.json is not None
     assert (
         response.json["message"]
-        == """Title: Only contain alphanumeric characters and spaces, and must include at least one letter.,\n Path: Only contain alphanumeric characters, no spaces, and must include at least one letter."""
+        == """Title: Only contain alphanumeric characters, hyphens(not at the start or end), spaces,and must include at least one letter.,\n Path: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."""
     )
     # Invalid name, title
     response = client.get(
@@ -677,7 +677,7 @@ def test_form_name_invalid_form_name_title_path(
     assert response.json is not None
     assert (
         response.json["message"]
-        == """Title: Only contain alphanumeric characters and spaces, and must include at least one letter.,\n Name: Only contain alphanumeric characters, no spaces, and must include at least one letter."""
+        == """Title: Only contain alphanumeric characters, hyphens(not at the start or end), spaces,and must include at least one letter.,\n Name: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."""
     )
     # Invalid path, name
     response = client.get(
@@ -687,7 +687,7 @@ def test_form_name_invalid_form_name_title_path(
     assert response.json is not None
     assert (
         response.json["message"]
-        == """Path: Only contain alphanumeric characters, no spaces, and must include at least one letter.,\n Name: Only contain alphanumeric characters, no spaces, and must include at least one letter."""
+        == """Path: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter.,\n Name: Only contain alphanumeric characters, hyphens(not at the start or end), no spaces,and must include at least one letter."""
     )
 
 


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
-  Hyphen allowed in form title, path & name but not in start or end

# Screenshots
![image](https://github.com/user-attachments/assets/c86e268c-e91d-4d0a-bf02-4d596d5600f6)
![image](https://github.com/user-attachments/assets/cea8a9ef-2c42-41ca-8955-9128ca7102f8)
![image](https://github.com/user-attachments/assets/32ccdd42-fda1-45e4-bd90-b77170e7c548)


# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request