### PR TITLE
FWF-2459 [Bugfix] Task loading fix by fetching latest data on each update called after 2 seconds

### DIFF
--- a/forms-flow-web/src/components/ServiceFlow/details/TaskHeaderListView.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/TaskHeaderListView.js
@@ -20,7 +20,7 @@ import {
 } from "../../../apiManager/services/bpmTaskServices";
 import { setBPMTaskDetailUpdating } from "../../../actions/bpmTaskActions";
 import UserSelectionDebounce from "./UserSelectionDebounce";
-import SocketIOService from "../../../services/SocketIOService";
+// import SocketIOService from "../../../services/SocketIOService";
 import { useTranslation } from "react-i18next";
 import  userRoles   from "../../../constants/permissions";
 
@@ -29,7 +29,7 @@ const TaskHeaderListView = React.memo(({task,taskId,groupView = true}) => {
     (state) => state.user?.userDetail?.preferred_username || ""
   );
   const taskGroups = useSelector((state) => state.bpmTasks.taskGroups);
-  const selectedFilter = useSelector((state) => state.bpmTasks.selectedFilter);
+  // const selectedFilter = useSelector((state) => state.bpmTasks.selectedFilter);
   const reqData = useSelector((state) => state.bpmTasks.listReqParams);
   const vissibleAttributes = useSelector((state) => state.bpmTasks.vissibleAttributes);
   const firstResult = useSelector((state) => state.bpmTasks.firstResult);
@@ -53,20 +53,28 @@ const TaskHeaderListView = React.memo(({task,taskId,groupView = true}) => {
   }, [task?.due]);
 
   const updateBpmTasksAndDetails = (err) =>{
-    if (!err) {
-      if (!SocketIOService.isConnected()) {
-        if (selectedFilter) {
-          dispatch(getBPMTaskDetail(taskId));
-          dispatch(
-            fetchServiceTaskList(reqData,null,firstResult)
-          );
-        } else {
-          dispatch(setBPMTaskDetailUpdating(false));
-        }
-      }
-    } else {
+    // if (!err) {
+    //   if (!SocketIOService.isConnected()) {
+    //     if (selectedFilter) {
+    //       dispatch(getBPMTaskDetail(taskId));
+    //       dispatch(
+    //         fetchServiceTaskList(reqData,null,firstResult)
+    //       );
+    //     } else {
+    //       dispatch(setBPMTaskDetailUpdating(false));
+    //     }
+    //   }
+    // } else {
+    //   dispatch(setBPMTaskDetailUpdating(false));
+    // }
+    // Above code commented and added below 3 lines for refreshing the tasks on each update operation without checking conditions.
+    if(err)
+      console.log('Error in task updation-',err);
+    setTimeout(() => {
+      dispatch(getBPMTaskDetail(taskId));
+      dispatch(fetchServiceTaskList(reqData,null,firstResult));
       dispatch(setBPMTaskDetailUpdating(false));
-    }
+    },2000);
   };
 
   const onClaim = () => {

--- a/forms-flow-web/src/components/ServiceFlow/details/TaskHeaderListView.js
+++ b/forms-flow-web/src/components/ServiceFlow/details/TaskHeaderListView.js
@@ -41,6 +41,7 @@ const TaskHeaderListView = React.memo(({task,taskId,groupView = true}) => {
 
   const dispatch = useDispatch();
   const { t } = useTranslation();
+  const RETRY_DELAY_TIME = 2000;
 
   useEffect(() => {
     const followUp = task?.followUp ? new Date(task?.followUp) : null;
@@ -70,11 +71,7 @@ const TaskHeaderListView = React.memo(({task,taskId,groupView = true}) => {
     // Above code commented and added below 3 lines for refreshing the tasks on each update operation without checking conditions.
     if(err)
       console.log('Error in task updation-',err);
-    setTimeout(() => {
-      dispatch(getBPMTaskDetail(taskId));
-      dispatch(fetchServiceTaskList(reqData,null,firstResult));
-      dispatch(setBPMTaskDetailUpdating(false));
-    },2000);
+    retryTaskUpdate(taskId, reqData, firstResult, dispatch);
   };
 
   const onClaim = () => {
@@ -153,6 +150,15 @@ const TaskHeaderListView = React.memo(({task,taskId,groupView = true}) => {
 
   const getGroups = (groups) => {
     return groups?.map((group) => group.groupId).join(", ");
+  };
+
+  // Utility function for retry logic
+  const retryTaskUpdate = (taskId, reqData, firstResult, dispatch) => {
+    setTimeout(() => {
+      dispatch(getBPMTaskDetail(taskId));
+      dispatch(fetchServiceTaskList(reqData, null, firstResult));
+      dispatch(setBPMTaskDetailUpdating(false));
+    }, RETRY_DELAY_TIME);
   };
 
   return (


### PR DESCRIPTION
FWF-2459 [Bugfix] Task loading fix by avoiding conditions inside updateBPMNTask method so all latest data fetched on each update

# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-2459
Issue Type: BUG

# Changes
- Calling updateBPMNTask() after any change in task page(claim,unclaim,datechange, etc..)
- Added a timeout of 2 seconds to get the latest data. 

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request