### PR TITLE
Remove CI action on merge to save CI hours

### DIFF
--- a/.github/workflows/forms-flow-api-ci.yml
+++ b/.github/workflows/forms-flow-api-ci.yml
@@ -2,11 +2,11 @@ name: Forms Flow API CI
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - develop
-      - master
-      - release/**
+  # push:
+  #   branches:
+  #     - develop
+  #     - master
+  #     - release/**
   pull_request:
     branches:
       - develop

--- a/.github/workflows/forms-flow-bpm-ci.yml
+++ b/.github/workflows/forms-flow-bpm-ci.yml
@@ -1,11 +1,11 @@
 name: Forms Flow BPM CI
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - develop
-      - master
-      - release/**
+  # push:
+  #   branches:
+  #     - develop
+  #     - master
+  #     - release/**
   pull_request:
     branches:
       - develop

--- a/.github/workflows/forms-flow-documents-ci.yml
+++ b/.github/workflows/forms-flow-documents-ci.yml
@@ -2,11 +2,11 @@ name: Forms Flow Document CI
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - develop
-      - master
-      - release/**
+  # push:
+  #   branches:
+  #     - develop
+  #     - master
+  #     - release/**
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
- Removing CI action on push
- Currently CI runs on both PR and upon merge, since CI is checked during PR we dont really need this to run on merge
- Github actions comes with certain free hours, running more actions accumulates more usage

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request