### PR TITLE
[Bugfix] currentUserRoles data to be fetched from groups variable from 'userDetails' localstorage instead of roles variable

### DIFF
--- a/forms-flow-web/src/constants/applicationComponent.js
+++ b/forms-flow-web/src/constants/applicationComponent.js
@@ -131,7 +131,7 @@ export const addHiddenApplicationComponent = (form) => {
       label: "Current User Roles", 
       persistent: true,
       key: "currentUserRole", 
-      customDefaultValue: "const localdata = localStorage.getItem('UserDetails') &&  JSON.parse(localStorage.getItem('UserDetails'));  value = localdata?.role || [];" 
+      customDefaultValue: "const localdata = localStorage.getItem('UserDetails') && (JSON.parse(localStorage.getItem('UserDetails'))) || []; value = localdata?.groups?.map(group => group.replace(new RegExp('^/+|/+$', 'g'), '')) || [];" 
     },
     // { 
     //   label: "All Available Roles", 


### PR DESCRIPTION
# Issue Tracking

Issue Type: BUG
# Changes

currentUserRoles data to be fetched from groups variable from 'userDetails' localstorage instead of roles variable.
These are the roles listed in our ROLES page in app , but from technical side, the variable name is 'groups'

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request