### PR TITLE
Bugfix: FWF-3748:  Fix keyerror for a user with create_designs and create_submissions on accessing formlist with includeSubmissionsCount=true 

### DIFF
--- a/forms-flow-api/src/formsflow_api/resources/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/resources/form_process_mapper.py
@@ -321,6 +321,7 @@ class FormResourceList(Resource):
             is_designer=is_designer,
             active_forms=active_forms,
             include_submissions_count=include_submissions_count,
+            ignore_designer=ignore_designer,
         )
         return (
             (

--- a/forms-flow-api/src/formsflow_api/services/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/services/form_process_mapper.py
@@ -52,6 +52,7 @@ class FormProcessMapperService:  # pylint: disable=too-many-public-methods
         is_designer: bool,
         active_forms: bool,
         include_submissions_count: bool,
+        ignore_designer: bool,
         **kwargs,
     ):  # pylint: disable=too-many-arguments, too-many-locals
         """Get all forms."""
@@ -93,7 +94,13 @@ class FormProcessMapperService:  # pylint: disable=too-many-public-methods
             )
         mapper_schema = FormProcessMapperSchema()
         mappers_response = mapper_schema.dump(mappers, many=True)
-        if include_submissions_count and CREATE_SUBMISSIONS in user.roles:
+        # Submissions count should return only for user with create_submissions permission
+        # & client form listing with showForOnlyCreateSubmissionUsers param true
+        if (
+            include_submissions_count
+            and CREATE_SUBMISSIONS in user.roles
+            and ignore_designer
+        ):
             current_app.logger.debug("Fetching submissions count..")
             for mapper in mappers_response:
                 mapper["submissionsCount"] = (

--- a/forms-flow-api/tests/unit/api/test_form_process_mapper.py
+++ b/forms-flow-api/tests/unit/api/test_form_process_mapper.py
@@ -824,7 +824,7 @@ def test_form_list_submission_count(app, client, session, jwt, create_mapper):
     token = get_token(jwt, role=CREATE_SUBMISSIONS)
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
     # submissionsCount exclude draft and return submission count
-    response = client.get("/form?includeSubmissionsCount=true", headers=headers)
+    response = client.get("/form?includeSubmissionsCount=true&showForOnlyCreateSubmissionUsers=true", headers=headers)
     assert response.status_code == 200
     forms = response.json["forms"]
     assert len(forms) == 1


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-3748

# Changes
A KeyError on parent_form_id occurs when a user with _create_designs and create_submissions permissions uses the includeSubmissionsCount=true parameter. This happens because parent_form_id is not included in the select query for fetching forms (find_all_forms) for designers but is included for clients. To resolve this, add a showForOnlyCreateSubmissionUsers (ignore designer -> schema name) check before fetching the count.

# Screenshots 
![image](https://github.com/user-attachments/assets/6a883d90-bd34-48f0-9311-3c05e2f9f580)
After fix
![image](https://github.com/user-attachments/assets/a019b210-3c0c-41eb-a468-24e5fa79e8c5)


# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request