### PR TITLE
Updated zap-scan.yml: Updated zap action version to v0.12.0

### DIFF
--- a/.github/workflows/zap-scan.yml
+++ b/.github/workflows/zap-scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: ZAP Scan
         id: zap_scan
-        uses: zaproxy/action-full-scan@v0.8.0
+        uses: zaproxy/action-full-scan@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target: ${{ secrets.WEB_TARGET_URL }}


### PR DESCRIPTION
- fix: update zaproxy/action-full-scan to v0.12.0 to fix artifact upload error

The workflow was failing with an error ("Create Artifact Container failed: The artifact name zap_scan is not valid") when using outdated zaproxy/action-full-scan@v0.8.0. Upgrading to v0.12.0 resolves the issue by handling artifact naming correctly.
