### PR TITLE
[Bugfix] Updation actions/cache v4 from v2 in forms-flow-root-config-…

### DIFF
--- a/.github/workflows/forms-flow-root-config-cd.yml
+++ b/.github/workflows/forms-flow-root-config-cd.yml
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ matrix.name }}-${{ github.sha }}


### PR DESCRIPTION
…cd.yml

# Issue Tracking


Issue Type: BUG

# Changes
 Updation actions/cache v4 from v2 in forms-flow-root-config
 as we came across build failure in https://github.com/AOT-Technologies/forms-flow-ai/actions/runs/13649871117/job/38155814714
 
 Change suggested from : 
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down


# Screenshots (if applicable)
<img width="1027" alt="Screenshot 2025-03-04 at 2 46 00 PM" src="https://github.com/user-attachments/assets/0faf0b58-a86d-4718-9e0f-6d0b994d5bb4" />


# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request