### PR TITLE
Update FilterSchema to use List of Dicts for variables  instead of VariableSchema

### DIFF
--- a/forms-flow-api/src/formsflow_api/schemas/filter.py
+++ b/forms-flow-api/src/formsflow_api/schemas/filter.py
@@ -31,7 +31,9 @@ class FilterSchema(AuditDateTimeSchema):
     description = fields.Str(allow_none=True)
     resource_id = fields.Str(data_key="resourceId", allow_none=True)
     criteria = fields.Dict()
-    variables = fields.List(fields.Nested(VariableSchema))
+    variables = fields.List(
+        fields.Dict()
+    )  # Add fields.Nested(VariableSchema) when fields for Variable schema is fixed
     properties = fields.Dict()
     roles = fields.List(fields.Str())
     users = fields.List(fields.Str())


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
Update FilterSchema to use List of Dicts for variables  instead of VariableSchema to adapt to new fields in task filter UI

Once the fields are fixed we can update the variable schema & use it

# Screenshots
![image](https://github.com/user-attachments/assets/f15dba25-f822-4262-aa4b-55bd9163c400)

# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request