### PR TITLE
bugfix/FWF-4659 [bugfix] client journey submission date fix

### DIFF
--- a/forms-flow-web/src/components/Form/constants/ClientTable.js
+++ b/forms-flow-web/src/components/Form/constants/ClientTable.js
@@ -196,7 +196,7 @@ function ClientTable() {
                         </td>
                         <td
                           data-testid={`latest-submission-${e._id}`} className="w-13">
-                          {formatDate(e.modified)}
+                          {formatDate(e.latestSubmission)}
                         </td>
 
                         <td className=" w-12 ">


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG
https://aottech.atlassian.net/browse/FWF-4659
DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Bug fix


___

### **Description**
- Use `latestSubmission` instead of `modified` date


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClientTable.js</strong><dd><code>Use latestSubmission field for date formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/constants/ClientTable.js

<li>Changed date property from <code>e.modified</code> to <code>e.latestSubmission</code><br> <li> Updated <code>formatDate</code> input to reflect latest submission


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2753/files#diff-23e1bd11bd91d1eeda9eabda1f72083be802a29a8dd2d50e93aab8ce3c61e87f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>