### PR TITLE
FWF-4597 [Bugfix] Submission unauthorized issue if form is loaded as initial screen fixed

### DIFF
--- a/forms-flow-web/src/components/PrivateRoute.jsx
+++ b/forms-flow-web/src/components/PrivateRoute.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import React, { useEffect, Suspense, useMemo, useCallback, useState } from "react";
+import React, { useEffect, Suspense, useMemo, useCallback } from "react";
 import { Route, Switch, Redirect, useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -82,7 +82,7 @@ const PrivateRoute = React.memo((props) => {
   const [authError, setAuthError] = React.useState(false);
   const [kcInstance, setKcInstance] = React.useState(getKcInstance());
   const [tenantValid, setTenantValid] = React.useState(true);
-  const [formioTokenSet, setFormioTokenSet] = useState(false);
+  const [formioTokenSet, setFormioTokenSet] = React.useState(false);
   const ROUTE_TO = getRoute(tenantId);
   const {
     admin,


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-4597
Issue Type: BUG
DEPENDENCY PR:
# Changes
Submission unauthorized issue if form is loaded as initial screen fixed
Added an extra check to load submission screen only after formiotoken is available . If it is not available, setting it and then loading the route. 

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Bug fix


___

### **Description**
- Track Formio token availability before form load

- Introduce formioTokenSet state and effects

- Update getFormioRoleIds callback to set token state

- Conditionally render form routes or loading screen


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PrivateRoute.jsx</strong><dd><code>Track Formio token before form rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/PrivateRoute.jsx

<li>Added formioTokenSet state to track token readiness<br> <li> Introduced useEffect for localStorage token check<br> <li> Updated getFormioRoleIds callback to set token state<br> <li> Conditional rendering: form route or loading spinner


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2756/files#diff-918e1af560feeec5805baf2ed4ede632c429c65adba87ebd8f997a0567d9baaa">+18/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>