### PR TITLE
modified/FWF-4454 [modified] fixed sort and view redirect issue

### DIFF
--- a/forms-flow-web/src/_tests_/unit/ClientTable.test.js
+++ b/forms-flow-web/src/_tests_/unit/ClientTable.test.js
@@ -80,7 +80,7 @@ beforeEach(() => {
       submitFormSort: {
         activeKey: "formName",
         formName: { sortOrder: "asc" },
-        modified: { sortOrder: "asc" },
+        latestSubmission: { sortOrder: "asc" },
         submissionCount: { sortOrder: "asc" },
       }
     },
@@ -142,7 +142,7 @@ it('should handle form name column sorting', async () => {
         formName: expect.objectContaining({
           sortOrder: 'desc', // Adjust this based on expected sort order
         }),
-        modified: expect.objectContaining({
+        latestSubmission: expect.objectContaining({
           sortOrder: 'asc',
         }),
         submissionCount: expect.objectContaining({
@@ -173,7 +173,7 @@ it('should handle submission count column sorting', async () => {
         formName: expect.objectContaining({
           sortOrder: 'asc', // Adjust this based on expected sort order
         }),
-        modified: expect.objectContaining({
+        latestSubmission: expect.objectContaining({
           sortOrder: 'asc',
         }),
         submissionCount: expect.objectContaining({
@@ -184,26 +184,28 @@ it('should handle submission count column sorting', async () => {
   );
 });
 
-it('should handle latest submission (Modified) column sorting', async () => {
+it('should handle latest submission column sorting', async () => {
   const sortButton = screen.getByTestId('Latest Submission-header-btn');
   fireEvent.click(sortButton);
+  
   // The first call should be a function (thunk)
   const dispatchedFunction = store.dispatch.mock.calls[0][0];
-  expect(typeof dispatchedFunction).toBe('function');  // Confirm it's a function (thunk)
-
+  expect(typeof dispatchedFunction).toBe('function');
+  
+  // Confirm it's a function (thunk)
   // Now invoke the thunk with store.dispatch
   dispatchedFunction(store.dispatch);
-
+  
   // Now we can check the second call to dispatch
   expect(store.dispatch).toHaveBeenCalledWith(
     expect.objectContaining({
       type: 'CLIENT_SUBMIT_LIST_SORT_CHANGE', // Updated to match the actual action type
       payload: expect.objectContaining({
-        activeKey: 'modified',
+        activeKey: 'latestSubmission',
         formName: expect.objectContaining({
           sortOrder: 'asc',
         }),
-        modified: expect.objectContaining({
+        latestSubmission: expect.objectContaining({
           sortOrder: 'desc',
         }),
         submissionCount: expect.objectContaining({
@@ -213,6 +215,7 @@ it('should handle latest submission (Modified) column sorting', async () => {
     })
   );
 });
+
 it('should render the selected form correctly', () => {
   // Create a spy on the navigateToFormEntries function
   const navigateSpy = jest.spyOn(require('../../helper/routerHelper'), 'navigateToFormEntries');

--- a/forms-flow-web/src/components/Form/constants/ClientTable.js
+++ b/forms-flow-web/src/components/Form/constants/ClientTable.js
@@ -140,7 +140,7 @@ function ClientTable() {
 
                 <th className="w-13" scope="col" data-testid="latest-submission-header">
                   <SortableHeader
-                    columnKey="modified"
+                    columnKey="latestSubmission"
                     title={t("Latest Submission")}
                     currentSort={formsort}
                     handleSort={handleSort}

--- a/forms-flow-web/src/modules/bpmFormReducer.js
+++ b/forms-flow-web/src/modules/bpmFormReducer.js
@@ -27,7 +27,7 @@ const initialState = {
   submitFormSort: {
     activeKey: "formName",
     formName: { sortOrder: "asc" },
-    modified: { sortOrder: "asc" },
+    latestSubmission: { sortOrder: "asc" },
     submissionCount: { sortOrder: "asc" },
     visibility: { sortOrder: "asc" },
     status: { sortOrder: "asc" },

--- a/forms-flow-web/src/routes/Submit/Forms/SubmitList.js
+++ b/forms-flow-web/src/routes/Submit/Forms/SubmitList.js
@@ -62,7 +62,7 @@ const SubmitList = React.memo(({ getFormsInit }) => {
   const optionSortBy = [
     { value: "formName", label: t("Form Name") },
     { value: "submissionCount", label: t("Submissions") },
-    { value: "modified", label: t("Latest Submission") },
+    { value: "latestSubmission", label: t("Latest Submission") },
   ];
 
   // Fetch Forms Function

--- a/forms-flow-web/src/routes/Submit/Submission/SubmissionView.js
+++ b/forms-flow-web/src/routes/Submit/Submission/SubmissionView.js
@@ -47,7 +47,9 @@ const ViewApplication = React.memo(() => {
   const submission = useSelector((state) => state.submission?.submission || {});
   const form = useSelector((state) => state.form?.form || {});
   const [showHistoryModal, setShowHistoryModal] = useState(false);
-  const [formId,setFormId] = useState();
+  const parentFormId = useSelector(
+    (state) => state.form.form?.parentFormId
+  );
   const { appHistory, isHistoryListLoading } = useSelector(
     useMemo(() => (state) => ({
       appHistory: state.taskAppHistory.appHistory,
@@ -64,7 +66,6 @@ const ViewApplication = React.memo(() => {
     dispatch(
       getApplicationById(applicationId, (err, res) => {
         if (!err) {
-          setFormId(res.formId);
           if (res.submissionId && res.formId) {
             dispatch(getForm("form", res.formId));
             if (CUSTOM_SUBMISSION_URL && CUSTOM_SUBMISSION_ENABLE) {
@@ -109,7 +110,7 @@ const ViewApplication = React.memo(() => {
   }
 
   const backToSubmissionList = () => {
-    navigateToFormEntries(dispatch, tenantKey, formId);
+    navigateToFormEntries(dispatch, tenantKey, parentFormId);
   };
 
   return (


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Rename sort key `modified` to `latestSubmission`

- Update ClientTable unit tests accordingly

- Adjust components and reducer for new key

- Use `parentFormId` for back navigation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClientTable.test.js</strong><dd><code>Update tests for `latestSubmission` sort</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/_tests_/unit/ClientTable.test.js

<li>Updated sort key from <code>modified</code> to <code>latestSubmission</code><br> <li> Adjusted expected payload in dispatch assertions<br> <li> Simplified latest submission sorting test<br> <li> Added comments for thunk dispatch checks


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2760/files#diff-02cec3ef572de7fe74176f4fa339c3930ea45c2a4267eaa23dae63b4988798a3">+12/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClientTable.js</strong><dd><code>Rename columnKey to `latestSubmission`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/constants/ClientTable.js

<li>Renamed <code>columnKey</code> from <code>modified</code> to <code>latestSubmission</code><br> <li> Updated <code>SortableHeader</code> prop to match new key


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2760/files#diff-23e1bd11bd91d1eeda9eabda1f72083be802a29a8dd2d50e93aab8ce3c61e87f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bpmFormReducer.js</strong><dd><code>Update reducer sort key to `latestSubmission`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/modules/bpmFormReducer.js

- Changed initialState sort key `modified` to `latestSubmission`


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2760/files#diff-7946ffc38de8a2fc881af25ada4ac262e0689f94b7ee91c1375c590301c59e63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SubmitList.js</strong><dd><code>Replace modified sort option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Submit/Forms/SubmitList.js

- Updated optionSortBy value from `modified` to `latestSubmission`


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2760/files#diff-b79fe8d30a9ac7652f898cd7e543f58b9b503b8ef290fdca883c80ef50e9ddf6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SubmissionView.js</strong><dd><code>Use `parentFormId` for navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Submit/Submission/SubmissionView.js

<li>Removed local <code>formId</code> state in favour of <code>parentFormId</code> selector<br> <li> Updated <code>backToSubmissionList</code> to use <code>parentFormId</code>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2760/files#diff-9c7ef058765137bdc8e30fd68f694d8a0a585709e326766b8de274fa647bd845">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>