### PR TITLE
FWF-4825 [fixed] formid replace when click back button from submission page

### DIFF
--- a/forms-flow-web/src/routes/Submit/Forms/UserForm.js
+++ b/forms-flow-web/src/routes/Submit/Forms/UserForm.js
@@ -298,7 +298,7 @@ const View = React.memo((props) => {
 
   // will be updated once application/draft listing page is ready
   const handleBack = () => {
-    navigateToFormEntries(dispatch, tenantKey, parentFormId);
+    navigateToFormEntries(dispatch, tenantKey, parentFormId || formId);
 
   };
 
@@ -426,7 +426,7 @@ const doProcessActions = (submission, draftId, ownProps, formId) => {
     const tenantKey = state.tenants?.tenantId;
     const redirectUrl = MULTITENANCY_ENABLED ? `/tenant/${tenantKey}/` : `/`;
     const origin = `${window.location.origin}${redirectUrl}`;
-    let parentFormId = form?.parentFormId; 
+    let parentFormId = form?.parentFormId || form?._id; 
     dispatch(resetSubmissions("submission"));
     const data = getProcessReq(form, submission._id, origin, submission?.data);
     const draftIdToUse = draftId || state.draft?.draftSubmission?.applicationId;


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-4825
Issue Type: BUG/ FEATURE
DEPENDENCY PR:

1. added FormId if there is no parentFormId

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Bug fix


___

### **Description**
- Added fallback to current form ID for back navigation

- Use form._id when parentFormId is missing in actions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserForm.js</strong><dd><code>Add fallback form ID for navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Submit/Forms/UserForm.js

<li>Back button navigation uses <code>formId</code> if no <code>parentFormId</code><br> <li> Submission process uses <code>form._id</code> fallback for <code>parentFormId</code>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2786/files#diff-dc53ddd005a519a1191e97664e22fb9a762fc5e1b368d2e2a45d2640c812c884">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>