### PR TITLE
FWF-4884: Documents API fixes

### DIFF
--- a/forms-flow-api-utils/src/formsflow_api_utils/utils/pdf.py
+++ b/forms-flow-api-utils/src/formsflow_api_utils/utils/pdf.py
@@ -92,7 +92,7 @@ def get_pdf_from_html(path, chromedriver=None, p_options=None, args=None):
 
     try:
         if "wait" in args:
-            delay = 30  # seconds
+            delay = 60  # seconds
             elem_loc = EC.presence_of_element_located((By.CLASS_NAME, args["wait"]))
             WebDriverWait(driver, delay).until(elem_loc)
         calculated_print_options = {

--- a/forms-flow-documents/src/formsflow_documents/app.py
+++ b/forms-flow-documents/src/formsflow_documents/app.py
@@ -102,6 +102,8 @@ def create_app(
                 HTTPStatus.FORBIDDEN,
                 HTTPStatus.NOT_FOUND,
             ]:
+                if not getattr(g, "token_info", None) or "locale" not in g.token_info:
+                    return response
                 lang = g.token_info["locale"]
                 if lang == "en":
                     return response

--- a/forms-flow-documents/src/formsflow_documents/app.py
+++ b/forms-flow-documents/src/formsflow_documents/app.py
@@ -102,7 +102,8 @@ def create_app(
                 HTTPStatus.FORBIDDEN,
                 HTTPStatus.NOT_FOUND,
             ]:
-                if not getattr(g, "token_info", None) or "locale" not in g.token_info:
+                token_info = getattr(g, "token_info", {})
+                if not isinstance(token_info, dict) or "locale" not in token_info:
                     return response
                 lang = g.token_info["locale"]
                 if lang == "en":

--- a/forms-flow-documents/src/formsflow_documents/resources/pdf.py
+++ b/forms-flow-documents/src/formsflow_documents/resources/pdf.py
@@ -52,7 +52,7 @@ class FormResourceRenderPdf(Resource):
             f"Inside Get RENDER form_id : {form_id}, submission_id : {submission_id}"
         )
         pdf_service = PDFService(form_id=form_id, submission_id=submission_id)
-        current_app.logger.info("Created PDF Service class instance")
+        current_app.logger.debug("Created PDF Service class instance")
         default_template = "index.html"
         template_name = request.args.get("template_name")
         template_variable_name = request.args.get("template_variable")
@@ -90,7 +90,7 @@ class FormResourceRenderPdf(Resource):
         render_data = pdf_service.get_render_data(
             use_template, template_variable_name, request.headers.get("Authorization")
         )
-        current_app.logger.info("Render data received")
+        current_app.logger.debug("Render data received")
         headers = {"Content-Type": "text/html"}
         return make_response(
             render_template(template_name, **render_data), 200, headers

--- a/forms-flow-documents/src/formsflow_documents/templates/index.html
+++ b/forms-flow-documents/src/formsflow_documents/templates/index.html
@@ -3,15 +3,15 @@
     <meta charset="utf-8" />
     <link
       rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"
+      href="{{ url_for('static', filename='css/font-awesome.min.css') }}"
     />
     <link
       rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+      href="{{ url_for('static', filename='css/bootstrap.min.css') }}"
     />
     <link
       rel="stylesheet"
-      href="https://cdn.form.io/formiojs/formio.full.min.css"
+      href="{{ url_for('static', filename='css/formio.full.min.css') }}"
     />
     <style type="text/css" media="print">
       .formio-component {
@@ -64,11 +64,11 @@
 
     <script
       defer
-      src="https://cdn.form.io/formiojs/formio.full.min.js"
+      src="{{ url_for('static', filename='js/formio.full.min.js') }}"
     ></script>
     <script
       defer
-      src="https://unpkg.com/formsflow-formio-custom-elements/dist/customformio.js"
+      src="{{ url_for('static', filename='js/customformio.js') }}"
     ></script>
     <script
       defer


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-4884
DEPENDENCY PR:
# Changes

- Increase wait time for PDF generation
- A critical error is triggered during the translation process when certain fonts referenced in the local CSS file return a 404 error because they are unavailable. The translation is not getting the token info in this case, so it returns the response

# Screenshots 
![image](https://github.com/user-attachments/assets/a2dc8f8c-e714-4c01-ae9e-8ebf629d3ae8)

![image](https://github.com/user-attachments/assets/c3134b5c-ff3e-49af-926c-71c99396e017)


# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Double PDF generation wait time to 60 seconds

- Add `token_info` guard before locale access

- Downgrade PDF logs from info to debug

- Switch CSS/JS links to local static assets


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pdf.py</strong><dd><code>Extend PDF interceptor wait from 30s to 60s</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api-utils/src/formsflow_api_utils/utils/pdf.py

- Increased default wait time from 30s to 60s in interceptor


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2828/files#diff-d37d8b91520b7c2314461f5862bc53c939fb396d88367b7b3ef278564795e321">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Guard `token_info` before accessing `locale`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-documents/src/formsflow_documents/app.py

<li>Added <code>token_info</code> type and key presence check<br> <li> Return original response if <code>locale</code> missing


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2828/files#diff-880698f1dcb0ab92a32c14b685570df3d2338979a834bd4b4fd8a7c36ee9369e">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pdf.py</strong><dd><code>Use debug logs for PDF rendering steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-documents/src/formsflow_documents/resources/pdf.py

<li>Changed PDFService logs from info to debug<br> <li> Lowered log level for render data receipt


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2828/files#diff-8146f7265488adda95abc825c8fe38f00786888b64da706a4cb04f8225101bb7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Switch CDN references to static assets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-documents/src/formsflow_documents/templates/index.html

<li>Updated CSS links to use local static files<br> <li> Updated JS scripts to serve from static assets


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2828/files#diff-fd6c9f5b15cf9af7d45ef89a28990ebfc4de4815ae4278a4ac5b151485aeef03">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>