### PR TITLE
FWF-4917:  [Bugfix] Fix  error on  search by form fields

### DIFF
--- a/forms-flow-data-layer/src/graphql/service/submission_service.py
+++ b/forms-flow-data-layer/src/graphql/service/submission_service.py
@@ -187,9 +187,9 @@ class SubmissionService:
                 for row in data
             ],
             total_count=(
-                mongo_side_submissions.get("total_count")
+                mongo_side_submissions.get("total_count", 0)
                 if mongo_search
-                and parent_form_id  # if mongo side submission is empty then use webapi side submission count
+                and needs_mongo_submissions
                 else total_count
             ),
             page_no=page_no,

--- a/forms-flow-data-layer/src/models/formio/submission.py
+++ b/forms-flow-data-layer/src/models/formio/submission.py
@@ -71,8 +71,11 @@ class SubmissionsModel(Document):
         pipeline.append(SubmissionsModel._build_projection_stage(selected_form_fields))
         # Only add pagination if page_no and limit specified
         if page_no is not None and limit is not None:
-            total_items = await SubmissionsModel.aggregate(pipeline).to_list()
-            total = len(total_items)
+            # Get only the count (no document data)
+            count_pipeline = pipeline + [{"$count": "total"}]
+            count_result = await SubmissionsModel.aggregate(count_pipeline).to_list(length=1)
+            total = count_result[0]["total"] if count_result else 0
+            # Add skip and limit stages for pagination
             pipeline.append({"$skip": (page_no - 1) * limit})
             pipeline.append({"$limit": limit})
             items = await SubmissionsModel.aggregate(pipeline).to_list()


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
DEPENDENCY PR:
# Changes

Fix  error on  search by form fields
- While searching by form fields, it was throwing the error "AggregationQuery' object has no attribute count"

# Screenshots
![image](https://github.com/user-attachments/assets/afdbad81-8227-45af-81ca-ac1123120882)

![image](https://github.com/user-attachments/assets/7c7d0857-1a49-4b65-aa61-cd25175656bc)

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Provide default 0 for missing mongo total_count

- Use needs_mongo_submissions flag selection

- Replace .count() with $count aggregation stage

- Add skip and limit for pagination


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Build aggregation pipeline"] --> B["Clone for count"]
  B --> C["Add $count stage"]
  C --> D["Fetch count result"]
  D --> E["Set total (or 0)"]
  A --> F["Add $skip and $limit"]
  F --> G["Fetch paginated items"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>submission_service.py</strong><dd><code>Fix total_count fallback logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-data-layer/src/graphql/service/submission_service.py

<li>Default <code>total_count</code> to 0 if missing<br> <li> Replace <code>parent_form_id</code> check with <code>needs_mongo_submissions</code><br> <li> Select between mongo and API total count correctly


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2859/files#diff-9576f233cec7dbc8b3f54aa6a91430fa19019011c650212f1dce02c4743a51dc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>submission.py</strong><dd><code>Optimize submission pagination count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-data-layer/src/models/formio/submission.py

<li>Replace <code>.count()</code> with aggregation <code>$count</code> stage<br> <li> Handle empty count result with zero fallback<br> <li> Add <code>$skip</code> and <code>$limit</code> stages for pagination


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2859/files#diff-4064df0d04ab7e4bd679872beacab57b72af35380e7117bfdcdbe3ebab1dcc39">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>