### PR TITLE
bugfix/fwf-4929-formId mismatch issue fix

### DIFF
--- a/forms-flow-web/src/components/Form/constants/ClientTable.js
+++ b/forms-flow-web/src/components/Form/constants/ClientTable.js
@@ -185,8 +185,8 @@ function ClientTable() {
                                   variant="secondary"
                                   size="table"
                                   label={t("Select")}
-                                  onClick={() => showFormEntries(e._id)}
-                                  dataTestId={`form-submit-button-${e._id}`}
+                                  onClick={() => showFormEntries(e.parentFormId)}
+                                  dataTestId={`form-submit-button-${e.parentFormId}`}
                                   aria-label={t("Select a form")}
                                   actionTable
                               />


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-4929
Issue Type: BUG/ FEATURE
DEPENDENCY PR:
# Changes
1.Normal formId changed to parentId in submissions

# Screenshots (if applicable)
<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/10a8a0fb-b819-49ca-b7c6-6616715bf327" />


# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Bug fix


___

### **Description**
- Use `parentFormId` for form selection callback

- Update `dataTestId` to use `parentFormId`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClientTable.js</strong><dd><code>Use parentFormId in form select button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/constants/ClientTable.js

<li>Changed <code>onClick</code> callback argument from <code>_id</code> to <code>parentFormId</code><br> <li> Updated <code>dataTestId</code> to use <code>parentFormId</code>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2865/files#diff-23e1bd11bd91d1eeda9eabda1f72083be802a29a8dd2d50e93aab8ce3c61e87f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>