### PR TITLE
Disabled deletion of outdated roles for existing realm clients.

### DIFF
--- a/forms-flow-idm/migration/migrate-7.1.0.py
+++ b/forms-flow-idm/migration/migrate-7.1.0.py
@@ -1,5 +1,5 @@
 
-from utils import get_access_token, get_client_id, add_client_roles, delete_client_role, update_client_role
+from utils import get_access_token, get_client_id, add_client_roles, update_client_role
 
 # New roles to be added to the forms-flow-web client
 roles_to_add = [
@@ -159,7 +159,6 @@ def _migrate_default():
         # Get client and group IDs
         client_id = get_client_id(token, "forms-flow-web")
         add_client_roles(token, client_id, roles_to_add)
-        delete_client_role(token,client_id, roles_to_remove)
         update_client_role(token, client_id, roles_to_update)
         
 


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
DEPENDENCY PR:

# Changes

- Disabled deletion of outdated roles for existing realm clients since groups with old roles can be used to map with new roles. For example, groups with manage_subflows, manage_decision_tables can be given manage_advance_workflows. 


# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request
