### PR TITLE
[Testing] Enable debug mode in web to test application in debug mode

### DIFF
--- a/forms-flow-web/craco.config.js
+++ b/forms-flow-web/craco.config.js
@@ -12,6 +12,7 @@ const singleSpaAppPlugin = {
     reactPackagesAsExternal: true, // defaults to true. marks react and react-dom as external so they are not included in the bundle
     minimize: shouldMinimize, // defaults to false, sets optimization.minimize value
     outputFilename: "forms-flow-web.js", // defaults to the values set for the "orgName" and "projectName" properties, in this case "my-org-my-app.js"
+     devtool: "source-map"
   },
 };
 
@@ -27,6 +28,7 @@ module.exports = {
           net: false,  // Unfortunately, net can't be polyfilled easily in the browser.
         },
       },
+      devtool:"source-map"
     },
   },
   devServer: {

--- a/forms-flow-web/package.json
+++ b/forms-flow-web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "craco start",
-    "build": "GENERATE_SOURCEMAP=false craco --max_old_space_size=6144 build",
+    "build": "GENERATE_SOURCEMAP=true craco --max_old_space_size=6144 build",
     "winBuild": "set \"GENERATE_SOURCEMAP=false\" && craco build",
     "eject": "react-scripts eject",
     "test": "craco test --detectOpenHandles --silent",


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Enhancement


___

### **Description**
- Enable source maps in CRACO SingleSpa plugin

- Activate devtool in webpack configuration

- Update build script to generate source maps


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>craco.config.js</strong><dd><code>Enable source maps in CRACO config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/craco.config.js

<ul><li>Added <code>devtool: "source-map"</code> to SingleSpaApp plugin options<br> <li> Enabled <code>devtool: "source-map"</code> in webpack.configure</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2899/files#diff-ee586448d38c475f574efaf407d1f009d8fe46a73473c0f865545ec85b5f6f21">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Enable sourcemaps in build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/package.json

<ul><li>Changed build script to <code>GENERATE_SOURCEMAP=true</code><br> <li> Ensures production builds include source maps</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2899/files#diff-ad0b98f386845a4d1cd0247b408ed0c9acc2e292f206bff2d518432c7ffaa945">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

