### PR TITLE
Revert "[Testing] Enable debug mode in web to test application in debug mode"

### DIFF
--- a/forms-flow-web/craco.config.js
+++ b/forms-flow-web/craco.config.js
@@ -12,7 +12,6 @@ const singleSpaAppPlugin = {
     reactPackagesAsExternal: true, // defaults to true. marks react and react-dom as external so they are not included in the bundle
     minimize: shouldMinimize, // defaults to false, sets optimization.minimize value
     outputFilename: "forms-flow-web.js", // defaults to the values set for the "orgName" and "projectName" properties, in this case "my-org-my-app.js"
-     devtool: "source-map"
   },
 };
 
@@ -28,7 +27,6 @@ module.exports = {
           net: false,  // Unfortunately, net can't be polyfilled easily in the browser.
         },
       },
-      devtool:"source-map"
     },
   },
   devServer: {

--- a/forms-flow-web/package.json
+++ b/forms-flow-web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "craco start",
-    "build": "GENERATE_SOURCEMAP=true craco --max_old_space_size=6144 build",
+    "build": "GENERATE_SOURCEMAP=false craco --max_old_space_size=6144 build",
     "winBuild": "set \"GENERATE_SOURCEMAP=false\" && craco build",
     "eject": "react-scripts eject",
     "test": "craco test --detectOpenHandles --silent",


### PR DESCRIPTION
### **User description**
Reverts AOT-Technologies/forms-flow-ai#2899


___

### **PR Type**
Bug fix


___

### **Description**
- Remove devtool settings in CRACO config

- Delete webpack devtool configuration

- Disable source maps in build script


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>craco.config.js</strong><dd><code>Remove source-map devtool configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/craco.config.js

<ul><li>Removed <code>devtool: "source-map"</code> from SingleSpaApp plugin options<br> <li> Deleted <code>devtool</code> setting under <code>webpack.configure</code></ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2904/files#diff-ee586448d38c475f574efaf407d1f009d8fe46a73473c0f865545ec85b5f6f21">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Disable source maps in build script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/package.json

- Changed build script `GENERATE_SOURCEMAP` to `false`


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2904/files#diff-ad0b98f386845a4d1cd0247b408ed0c9acc2e292f206bff2d518432c7ffaa945">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

