### PR TITLE
[Feature] Webapi: Add new param in formlist API to list all forms(active&inactive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This prevents the need to update attribute filters every time a task filter is m
 
 **formsflow-api**
 * Updated create_filters description from "Manage filters you create" to “Manage personal filters”
+* Introduced the allForms parameter in the form list endpoint to retrieve both active and inactive forms.
 
 *Upgrade notes:*
 

--- a/forms-flow-api/src/formsflow_api/models/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/models/form_process_mapper.py
@@ -352,6 +352,13 @@ class FormProcessMapper(
     ):
         """Fetch all the forms."""
         query = cls.tenant_authorization(query=cls.query)
+        # Fetch the latest non-deleted forms grouped by parent form ID.
+        filtered_form_query = cls.get_latest_form_mapper_ids()
+        filtered_form_ids = [data.id for data in filtered_form_query]
+        query = query.filter(
+            and_(FormProcessMapper.deleted.is_(False)),
+            FormProcessMapper.id.in_(filtered_form_ids),
+        )
         query = query.with_entities(
             cls.form_id,
             cls.form_name,

--- a/forms-flow-api/src/formsflow_api/models/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/models/form_process_mapper.py
@@ -345,6 +345,26 @@ class FormProcessMapper(
         return query.items, total_count
 
     @classmethod
+    def fetch_all_forms(
+        cls,
+        page_number=None,
+        limit=None,
+    ):
+        """Fetch all the forms."""
+        query = cls.tenant_authorization(query=cls.query)
+        query = query.with_entities(
+            cls.form_id,
+            cls.form_name,
+            cls.parent_form_id,
+            cls.status,
+        )
+        query = query.order_by(cls.form_name)
+        total_count = query.count()
+        limit = total_count if limit is None else limit
+        query = query.paginate(page=page_number, per_page=limit, error_out=False)
+        return query.items, total_count
+
+    @classmethod
     def find_forms_by_title(cls, form_title, exclude_id) -> FormProcessMapper:
         """Find all form process mapper that matches the provided form title."""
         latest_mapper = (

--- a/forms-flow-api/src/formsflow_api/resources/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/resources/form_process_mapper.py
@@ -7,6 +7,7 @@ from flask import request
 from flask_restx import Namespace, Resource, fields
 from formsflow_api_utils.exceptions import BusinessException
 from formsflow_api_utils.utils import (
+    ANALYZE_SUBMISSIONS_VIEW,
     CREATE_DESIGNS,
     CREATE_FILTERS,
     CREATE_SUBMISSIONS,
@@ -305,6 +306,7 @@ class FormResourceList(Resource):
             CREATE_FILTERS,
             VIEW_FILTERS,
             MANAGE_ALL_FILTERS,
+            ANALYZE_SUBMISSIONS_VIEW,
         ]
     )
     @profiletime
@@ -379,6 +381,7 @@ class FormResourceList(Resource):
         form_type: str = dict_data.get("form_type", None)
         is_active = dict_data.get("is_active", None)
         active_forms = dict_data.get("active_forms", None)
+        all_forms = dict_data.get("all_forms", False)
         # when ignore_designer true, exclude designer priorities like
         # listing both active and inactive forms or listing forms created by the designer.
         ignore_designer = dict_data.get("ignore_designer", False)
@@ -408,6 +411,7 @@ class FormResourceList(Resource):
             is_designer=is_designer,
             active_forms=active_forms,
             include_submissions_count=include_submissions_count,
+            all_forms=all_forms,
         )
         return (
             (

--- a/forms-flow-api/src/formsflow_api/schemas/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/schemas/form_process_mapper.py
@@ -79,3 +79,4 @@ class FormProcessMapperListRequestSchema(FormProcessMapperListReqSchema):
         data_key="includeSubmissionsCount", required=False
     )
     parentFormId = fields.Str(data_key="parentFormId", required=False)
+    all_forms = fields.Bool(data_key="allForms", required=False)

--- a/forms-flow-api/src/formsflow_api/services/form_process_mapper.py
+++ b/forms-flow-api/src/formsflow_api/services/form_process_mapper.py
@@ -53,6 +53,7 @@ class FormProcessMapperService:  # pylint: disable=too-many-public-methods
         is_designer: bool,
         active_forms: bool,
         include_submissions_count: bool,
+        all_forms: bool = False,
         **kwargs,
     ):  # pylint: disable=too-many-arguments, too-many-locals
         """Get all forms."""
@@ -61,6 +62,13 @@ class FormProcessMapperService:  # pylint: disable=too-many-public-methods
         current_app.logger.info(f"Listing forms for designer: {is_designer}")
         if active_forms:
             mappers, get_all_mappers_count = FormProcessMapper.find_all_active_forms(
+                page_number=page_number,
+                limit=limit,
+            )
+        elif all_forms:
+            # If all_forms is true, retrieve all forms regardless of their active status,
+            # skipping authorization checks except for tenant-specific forms.
+            mappers, get_all_mappers_count = FormProcessMapper.fetch_all_forms(
                 page_number=page_number,
                 limit=limit,
             )


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5149

DEPENDENCY PR:
# Changes

- Add new param in formlist API to list all forms(active&inactive)
- Fix Forms are not listing for user with only “Access to Analyze” permission - Added ANALYZE_SUBMISSIONS_VIEW permission to form list endpoint 


# Screenshots
<img width="1532" height="847" alt="image" src="https://github.com/user-attachments/assets/ca1716c7-c454-4276-b8d5-c7244527cea5" />

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [X] Updated changelog
- [X] Added meaningful title for pull request


___

### **PR Type**
Enhancement


___

### **Description**
- Add `fetch_all_forms` method for retrieving all forms

- Enable `allForms` flag in request schema and endpoint

- Update service to use `fetch_all_forms` when `all_forms` is true

- Include `ANALYZE_SUBMISSIONS_VIEW` role permission


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client Request"] --> B["Resource.get: list forms"]
  B --> C["Schema: parse allForms"]
  B --> D["Service.get_all_forms"]
  D --> E{"all_forms param?"}
  E -- "true" --> F["Model.fetch_all_forms"]
  E -- "false" --> G["Model.find_all_active_forms or authorized"]
  F --> H["Pagination and return"]
  G --> H
  H --> I["Response: forms list"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>form_process_mapper.py</strong><dd><code>Implement fetch_all_forms method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/src/formsflow_api/models/form_process_mapper.py

<ul><li>Added <code>fetch_all_forms</code> class method<br> <li> Filter non-deleted forms and group by parent_form_id<br> <li> Support pagination and ordering by <code>form_name</code></ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2910/files#diff-8478949413c6b115961259d4660d3534f92a0b0be49dddf9c67bceae309af7ce">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>form_process_mapper.py</strong><dd><code>Support allForms in resource endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/src/formsflow_api/resources/form_process_mapper.py

<ul><li>Added <code>ANALYZE_SUBMISSIONS_VIEW</code> to permissions<br> <li> Retrieved <code>all_forms</code> from request args<br> <li> Passed <code>all_forms</code> into service call</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2910/files#diff-03ec1738e9745151123e5c3c2daa8f4b1d590f4e47694dc8ea53f280c6310e7a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>form_process_mapper.py</strong><dd><code>Add allForms to request schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/src/formsflow_api/schemas/form_process_mapper.py

- Defined `all_forms` field with data_key `allForms`


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2910/files#diff-c48f299d4b61b6acef0ae801ffba9e8674550068ab89499c36acb2e49fd5262d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>form_process_mapper.py</strong><dd><code>Handle all_forms in service logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/src/formsflow_api/services/form_process_mapper.py

<ul><li>Added <code>all_forms</code> parameter to <code>get_all_forms</code><br> <li> Called <code>fetch_all_forms</code> when <code>all_forms</code> is true</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2910/files#diff-97cbdfbca9c09c2428c55b9cdc9c47a4df0b43fed400ae8f81536a49d25a0e29">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with allForms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/CHANGELOG.md

- Introduced `allForms` parameter entry in changelog


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

