### PR TITLE
FWF-5146:  Refactor datetime conversion to return ISO string format with milliseconds and 'Z'

### DIFF
--- a/forms-flow-data-layer/src/utils/datetime_utils.py
+++ b/forms-flow-data-layer/src/utils/datetime_utils.py
@@ -27,8 +27,11 @@ def _(obj: list):
 def _(obj: datetime):
     """Convert datetime object to ISO string format."""
     # Convert to desired ISO format with milliseconds and 'Z'
-    return (
-        obj.replace(tzinfo=timezone.utc)
-        .isoformat(timespec="milliseconds")
-        .replace("+00:00", "Z")
-    )
+    if obj.tzinfo is None:
+        # Assume naive datetimes are UTC (standard for databases like MongoDB)
+        obj = obj.replace(tzinfo=timezone.utc)
+    else:
+        # Convert aware datetimes to UTC (handles any timezone correctly)
+        obj = obj.astimezone(timezone.utc)
+    # Format with milliseconds and 'Z'
+    return obj.isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/forms-flow-data-layer/src/utils/datetime_utils.py
+++ b/forms-flow-data-layer/src/utils/datetime_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for converting datetime objects to string format."""
 from functools import singledispatch
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 @singledispatch
@@ -25,6 +25,10 @@ def _(obj: list):
 
 @convert_datetimes_to_string.register
 def _(obj: datetime):
-    """Convert datetime object to string format."""
-    # Convert datetime to string format eg: 04-08-2025, 06:30 AM
-    return obj.strftime("%d-%m-%Y, %I:%M %p")
+    """Convert datetime object to ISO string format."""
+    # Convert to desired ISO format with milliseconds and 'Z'
+    return (
+        obj.replace(tzinfo=timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5146
DEPENDENCY PR:
# Changes

- Refactor datetime conversion to return ISO string format with milliseconds and 'Z'

# Screenshots
<img width="1342" height="746" alt="image" src="https://github.com/user-attachments/assets/21bac936-b285-4972-a6d6-44dd1aa4676f" />

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request


___

### **PR Type**
Enhancement


___

### **Description**
- Convert datetimes to ISO 8601 UTC strings

- Handle naive and aware datetimes robustly

- Include milliseconds and trailing 'Z'

- Preserve list handling and string joining


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["datetime_utils.convert_datetimes_to_string(datetime)"] -- "detect tzinfo" --> B["naive -> set UTC tzinfo"]
  A -- "aware -> astimezone(UTC)" --> C["convert to UTC"]
  B -- "format ms + Z" --> D["ISO string e.g. 2025-04-08T06:30:00.000Z"]
  C -- "format ms + Z" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>datetime_utils.py</strong><dd><code>Datetime ISO 8601 UTC formatting with milliseconds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-data-layer/src/utils/datetime_utils.py

<ul><li>Import <code>timezone</code> for UTC handling.<br> <li> Convert naive datetimes to UTC explicitly.<br> <li> Normalize aware datetimes to UTC with <code>astimezone</code>.<br> <li> Format to ISO 8601 with milliseconds and trailing <code>Z</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2916/files#diff-dfb49c2ba6e2c4236daa6d2f9e28d940073e839bb3f03eccfc8343a0fb18ae1e">+11/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

