### PR TITLE
FWF-5193 [bugfix] updated the typo

### DIFF
--- a/forms-flow-web/src/components/Form/components/FormSettings.js
+++ b/forms-flow-web/src/components/Form/components/FormSettings.js
@@ -295,11 +295,11 @@ const FormSettings = forwardRef((props, ref) => {
           inputDropDownSelectedValue={rolesState?.DESIGN?.selectedOption}
           inputDropDownOptions={[
             {
-              label: t("Only You"),
+              label: t("Only owner"),
               value:"onlyYou",
             },
             {
-              label: t("You and specified roles"),
+              label: t("Owner and specific roles"),
               value: "specifiedRoles",
             },
           ]}


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5193
DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Bug fix


___

### **Description**
- Update form permission labels for clarity

- Replace "Only You" with "Only owner"

- Replace "You and specified roles" wording


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FormSettings.js labels"] -- "update text" --> B["Only owner"]
  A -- "update text" --> C["Owner and specific roles"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormSettings.js</strong><dd><code>Permission dropdown labels refined</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/components/FormSettings.js

<ul><li>Adjust dropdown labels for permissions.<br> <li> "Only You" -> "Only owner".<br> <li> "You and specified roles" -> "Owner and specific roles".<br> <li> No logic changes; translation keys via t(...) updated.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2923/files#diff-efa377aa8af48ba5325f1c37ab1041634bceb0580d89e66a153efabbed1635c2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

