### PR TITLE
 Add FormId to submission filter list API response

### DIFF
--- a/forms-flow-api/src/formsflow_api/resources/submissions_filter.py
+++ b/forms-flow-api/src/formsflow_api/resources/submissions_filter.py
@@ -60,7 +60,19 @@ analyze_submissions_response_model = API.inherit(
 filter_response_with_default_filter = API.model(
     "FilterResponseWithDefaultFilter",
     {
-        "filters": fields.List(fields.Nested(analyze_submissions_response_model)),
+        "filters": fields.List(
+            fields.Nested(
+                API.inherit(
+                    "AnalyzeSubmissionsResponseWithFormId",
+                    analyze_submissions_response_model,
+                    {
+                        "formId": fields.String(
+                            description="Form ID associated with the filter"
+                        ),
+                    },
+                )
+            )
+        ),
         "defaultSubmissionsFilter": fields.Integer(
             description="Default Submissions Filter ID of the user"
         ),

--- a/forms-flow-api/src/formsflow_api/schemas/submissions_filter.py
+++ b/forms-flow-api/src/formsflow_api/schemas/submissions_filter.py
@@ -41,6 +41,7 @@ class SubmissionsFilterSchema(Schema):
     parent_form_id = fields.Str(
         required=True, data_key="parentFormId", validate=not_empty_string
     )
+    form_id = fields.Str(dump_only=True, data_key="formId")
     variables = fields.List(
         fields.Nested(VariableSchema), required=True, validate=validate_non_empty_list
     )

--- a/forms-flow-api/tests/unit/api/test_submissions_filter.py
+++ b/forms-flow-api/tests/unit/api/test_submissions_filter.py
@@ -60,7 +60,7 @@ def test_create_analyze_submissions_filter(app, client, session, jwt):
     assert response.status_code == 401
 
 
-def test_get_analyze_submissions_filter_list(app, client, session, jwt):
+def test_get_analyze_submissions_filter_list(app, client, session, jwt, create_mapper_custom):
     """Test analyze submissions filter list."""
     token = get_token(jwt, role=ANALYZE_SUBMISSIONS_VIEW, username="reviewer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
@@ -68,6 +68,20 @@ def test_get_analyze_submissions_filter_list(app, client, session, jwt):
     response = client.get("/submissions-filter", headers=headers)
     assert response.json.get("filters") == []
     assert response.json.get("defaultSubmissionsFilter") is None
+    # Create form mapper entry
+    payload = {
+        "formId": "685bc0c99135c75802703046",
+        "formName": "Sample form",
+        "processKey": "onestepapproval",
+        "processName": "One Step Approval",
+        "status": "active",
+        "comments": "test",
+        "anonymous": False,
+        "formType": "form",
+        "parentFormId": "685bc0c99135c75802703046",
+    }
+    create_mapper_custom(payload)
+    # Create analyze submissions filter entry
     response = client.post(
         "/submissions-filter", headers=headers, json=filter_payload()
     )
@@ -79,6 +93,7 @@ def test_get_analyze_submissions_filter_list(app, client, session, jwt):
     filters = response.json.get("filters")
     assert len(filters) == 1
     assert filters[0].get("parentFormId") == "685bc0c99135c75802703046"
+    assert filters[0].get("formId") == "685bc0c99135c75802703046"
     assert response.json["filters"][0].get("id") is not None
     filter_id = response.json["filters"][0].get("id")
     # Add default submissions filter


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5305
DEPENDENCY PR:
# Changes

- Enhance submissions filter functionality by adding form ID to the response and updating the fetch method to join with FormProcessMapper for active filter
- FormId can be used to get the form fields in the variable selection modal. FormId changes when a new major version of the form is created


# Screenshots 
<img width="1112" height="852" alt="image" src="https://github.com/user-attachments/assets/47c7fb04-958e-4919-96cf-988fa8683807" />


# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request
