### PR TITLE
FWF-5316 [bugfix] updated permission for variable selection modal

### DIFF
--- a/forms-flow-web/src/routes/Design/Forms/FlowEdit.js
+++ b/forms-flow-web/src/routes/Design/Forms/FlowEdit.js
@@ -481,7 +481,7 @@ const FlowEdit = forwardRef(({ isPublished = false, CategoryType,
           form={form}
           show={showVariableModal}
           onClose={handleCloseVariableModal}
-          saveBtnDisabled={isPublished}
+          saveBtnDisabled={isPublished || !createDesigns}
           savedFormVariables={savedFormVariables}
           primaryBtnAction={handleSaveVariables}
           systemVariables={SystemVariables}


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG
https://aottech.atlassian.net/browse/FWF-5316
<img width="1909" height="974" alt="image" src="https://github.com/user-attachments/assets/c461ad0e-a415-494b-95c7-d3beeb7aae2f" />

DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Disable save when lacking create permission

- Honor publish state and permissions together

- Update variable modal save button logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FlowEdit.js"] --> B["VariableModal props"]
  B --> C["saveBtnDisabled = isPublished || !createDesigns"]
  C --> D["Properly disables Save button"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FlowEdit.js</strong><dd><code>Enforce permissions in VariableModal save control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Forms/FlowEdit.js

<ul><li>Extend <code>saveBtnDisabled</code> to include <code>!createDesigns</code>.<br> <li> Preserve existing <code>isPublished</code> condition.<br> <li> Ensures Save disabled without create permission.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2938/files#diff-d95599c421f12c7a01b4b740713077226216a80b155bbcd732abffdd3465a52a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

