### PR TITLE
FWF-5349 : [BugFix] Updated unpublish note section with CustomInfo component

### DIFF
--- a/forms-flow-web/src/routes/Design/Forms/FormEdit.js
+++ b/forms-flow-web/src/routes/Design/Forms/FormEdit.js
@@ -965,7 +965,17 @@ const handleSaveLayout = () => {
       case "unpublish":
         return {
           title: t("Unpublish"),
-          message: t( "By unpublishing this form & flow, you will make it unavailable for new submissions."),
+          message: (
+            <CustomInfo
+              className="note"
+              heading={t("Note")}
+              content={t(
+                "By unpublishing this form & flow, you will make it unavailable for new submissions."
+              )
+              }
+              dataTestId="unpublish-info"
+            />
+          ),
           primaryBtnAction: confirmPublishOrUnPublish,
           secondaryBtnAction: closeModal,
           primaryBtnText: t("Unpublish This Form & Flow"),


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: [FWF-5349/unpublish-note-section](https://aottech.atlassian.net/browse/FWF-5349) ( **Issue 8** )
Issue Type: BUG
DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace unpublish text with CustomInfo

- Add heading and test id for note

- Improve unpublish dialog accessibility

- Maintain existing actions and labels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Dialog["Unpublish dialog config"] -- "message replaced" --> CustomInfo["CustomInfo component"]
  CustomInfo -- "props: heading, content, dataTestId" --> UI["Improved note display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormEdit.js</strong><dd><code>Swap unpublish message to CustomInfo component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Forms/FormEdit.js

<ul><li>Replace plain message with CustomInfo JSX.<br> <li> Add <code>heading</code> as translated "Note".<br> <li> Keep translated unpublish content in <code>content</code>.<br> <li> Add <code>dataTestId</code> "unpublish-info" for testing.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2953/files#diff-77e52510df04afdc123ea687d48b039915d6dd1b0596d6557e522dad575f8b1a">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

