### PR TITLE
FWF-5390 [upgrade] updated the volume mounting on docker files

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       MONGO_INITDB_DATABASE: ${FORMIO_DB_NAME:-formio}
     volumes:
       - ./../../forms-flow-forms/mongo_entrypoint/001_user.js:/docker-entrypoint-initdb.d/001_user.js:ro
-      - ./mongodb/data/db/:/data/db/
-      - ./mongodb/data/log/:/var/log/mongodb/
+      - mongodb_data:/data/db/
+      - mongodb_logs:/var/log/mongodb/
       - ./mongodb/mongod.conf:/etc/mongod.conf
     networks:
       - forms-flow-network
@@ -56,7 +56,7 @@ services:
       POSTGRES_PASSWORD: ${CAMUNDA_JDBC_PASSWORD:-changeme}
       POSTGRES_DB: ${CAMUNDA_JDBC_DB_NAME:-formsflow-bpm}
     volumes:
-      - ./postgres/camunda:/var/lib/postgresql/data
+      - postgres_camunda:/var/lib/postgresql/data
     ports:
       - '5432:5432'
     restart: always
@@ -212,7 +212,7 @@ services:
       - '6432:5432'
     restart: always
     volumes:
-      - ./postgres/webapi:/var/lib/postgresql/data
+      - postgres_webapi:/var/lib/postgresql/data
     networks:
       - forms-flow-network
 
@@ -408,3 +408,7 @@ networks:
 volumes:
   mdb-data:
   postgres:
+  postgres_camunda:
+  postgres_webapi:
+  mongodb_data:
+  mongodb_logs:

--- a/forms-flow-analytics/docker-compose.yml
+++ b/forms-flow-analytics/docker-compose.yml
@@ -47,10 +47,13 @@ services:
     restart: always
     env_file: .env
     volumes:
-      - ./postgres/analytics:/var/lib/postgresql/data
+      - postgres_analytics:/var/lib/postgresql/data
   # Uncomment the following to enable redash mail server
   # email:
   #   image: djfarrelly/maildev
   #   ports:
   #     - "1080:80"
   #   restart: unless-stopped
+
+volumes:
+  postgres_analytics:

--- a/forms-flow-api/docker-compose.yml
+++ b/forms-flow-api/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - '6432:5432'
     restart: unless-stopped
     volumes:
-      - ./postgres/webapi:/var/lib/postgresql/data
+      - postgres_webapi:/var/lib/postgresql/data
     networks:
       - forms-flow-webapi-network
 
@@ -79,3 +79,4 @@ networks:
 
 volumes:
   mdb-data:
+  postgres_webapi:

--- a/forms-flow-bpm/docker-compose.yml
+++ b/forms-flow-bpm/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: ${CAMUNDA_JDBC_PASSWORD:-changeme}
       POSTGRES_DB: ${CAMUNDA_JDBC_DB_NAME:-formsflow-bpm}
     volumes:
-      - ./postgres/camunda:/var/lib/postgresql/data
+      - postgres_camunda:/var/lib/postgresql/data
     ports:
       - '5432:5432'
     restart: unless-stopped
@@ -86,3 +86,4 @@ networks:
 
 volumes:
   postgres:
+  postgres_camunda:

--- a/forms-flow-forms/docker-compose.yml
+++ b/forms-flow-forms/docker-compose.yml
@@ -28,8 +28,8 @@ services:
       MONGO_INITDB_DATABASE: ${FORMIO_DB_NAME:-formio}
     volumes:
       - ./mongo_entrypoint/001_user.js:/docker-entrypoint-initdb.d/001_user.js:ro
-      - ./mongodb/data/db/:/data/db/
-      - ./mongodb/data/log/:/var/log/mongodb/
+      - mongodb_data:/data/db/
+      - mongodb_logs:/var/log/mongodb/
       - ./mongodb/mongod.conf:/etc/mongod.conf
     networks:
       - forms-flow-forms-network
@@ -65,3 +65,5 @@ networks:
 
 volumes:
   mdb-data:
+  mongodb_data:
+  mongodb_logs:

--- a/forms-flow-idm/keycloak/docker-compose.yml
+++ b/forms-flow-idm/keycloak/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.7"
 
 volumes:
   postgres:
+  postgres_keycloak:
   keycloak_custom_data:
   
 networks:
@@ -15,7 +16,7 @@ services:
     restart: always
     container_name: keycloak_db
     volumes:
-      - ./postgres/keycloak:/var/lib/postgresql/data
+      - postgres_keycloak:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: ${KEYCLOAK_JDBC_DB:-keycloak}
       POSTGRES_USER: ${KEYCLOAK_JDBC_USER:-admin}


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5390
<img width="985" height="585" alt="image" src="https://github.com/user-attachments/assets/ab4e0609-f9f7-4055-882f-a6f00d042c41" />

DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Switch to named Docker volumes across services

- Replace host path mounts for databases

- Add volume declarations for new names

- Standardize compose files volume usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  FS["File-system path mounts"] -- "replace with" --> NV["Named Docker volumes"]
  NV -- "declared under" --> VD["volumes: definitions"]
  Services["MongoDB/Postgres services"] -- "mount" --> NV
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Migrate deployment compose to named volumes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deployment/docker/docker-compose.yml

<ul><li>Replace bind mounts with named volumes for MongoDB and Postgres.<br> <li> Add new volume names: <code>mongodb_data</code>, <code>mongodb_logs</code>, <code>postgres_camunda</code>, <br><code>postgres_webapi</code>.<br> <li> Update services to use named volumes.<br> <li> Extend global volumes section with new entries.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2955/files#diff-329b7958f0c02b372fa3e59410eb5ead3464e670dcf96d7b5bdc4fc890137ead">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Use named volume for analytics Postgres</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-analytics/docker-compose.yml

<ul><li>Replace analytics Postgres bind mount with <code>postgres_analytics</code> named <br>volume.<br> <li> Add volumes section declaring <code>postgres_analytics</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2955/files#diff-d06d6fa8e422b3cb6f333e30b6bd8db28aedb6b35594cbfc8e725be78e163eec">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Use named volume for API Postgres</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/docker-compose.yml

<ul><li>Replace webapi Postgres bind mount with <code>postgres_webapi</code> named volume.<br> <li> Declare <code>postgres_webapi</code> under volumes.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2955/files#diff-c553d6370c90694df929bde3a3cc026bf7082c9da0fd1ba3d374222ba1970e5a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Use named volume for BPM Postgres</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-bpm/docker-compose.yml

<ul><li>Replace Camunda Postgres bind mount with <code>postgres_camunda</code> named <br>volume.<br> <li> Declare <code>postgres_camunda</code> under volumes.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2955/files#diff-e5e517debcbc4d57d5cc58674ad646f6c36094fbc4d53ba779f664685c50c0cb">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Use named volumes for Forms MongoDB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-forms/docker-compose.yml

<ul><li>Replace MongoDB bind mounts with <code>mongodb_data</code> and <code>mongodb_logs</code> named <br>volumes.<br> <li> Declare <code>mongodb_data</code> and <code>mongodb_logs</code> under volumes.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2955/files#diff-5f7e9be19b4df76f17c262c37c44b8fe929b61a3ab67d0baf67d98774a424850">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Use named volume for Keycloak Postgres</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-idm/keycloak/docker-compose.yml

<ul><li>Replace Keycloak Postgres bind mount with <code>postgres_keycloak</code> named <br>volume.<br> <li> Add <code>postgres_keycloak</code> to volumes declarations.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2955/files#diff-7cc9ae6df38b9f7f96bee944438c7afd92dfa31f16def51159f1613f096a61c4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

