### PR TITLE
fixed the  the keycloak issue

### DIFF
--- a/forms-flow-bpm/Dockerfile
+++ b/forms-flow-bpm/Dockerfile
@@ -38,7 +38,7 @@ RUN chmod a+rwx -R /app
 RUN keytool -import -trustcacerts \
     -alias sslcom-cert \
     -file /app/sslcom.cer \
-    -keystore  /usr/java/openjdk-21/lib/security/cacerts \
+    -keystore  ${JAVA_HOME}/lib/security/cacerts \
     -storepass changeit \
     -noprompt
 WORKDIR /app


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
<img width="1425" height="589" alt="image" src="https://github.com/user-attachments/assets/d2fe6f80-10a7-4fa9-8863-b4045fd2035f" />

DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Use JAVA_HOME for cacerts path

- Improve Dockerfile portability and correctness


___

### Diagram Walkthrough


```mermaid
flowchart LR
  DF["Dockerfile certificate import"] -- "keystore path from hardcoded" --> OLD["/usr/java/openjdk-21/lib/security/cacerts"]
  DF -- "keystore path to env-based" --> NEW["${JAVA_HOME}/lib/security/cacerts"]
  NEW -- "ensures correct JRE truststore" --> KC["Keycloak SSL trust fixed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Use JAVA_HOME for cacerts keystore path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-bpm/Dockerfile

<ul><li>Replace hardcoded cacerts path with ${JAVA_HOME}<br> <li> Keep certificate import and permissions unchanged</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2962/files#diff-950b344f02fe3f0923c9ce0be6b7a734d7788e368472cf843127e301bc2d5e93">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

