### PR TITLE
feature/fwf-5275:added form settings tab component

### DIFF
--- a/forms-flow-web/src/routes/Design/Forms/FormEdit.js
+++ b/forms-flow-web/src/routes/Design/Forms/FormEdit.js
@@ -11,20 +11,13 @@ import {
 import {
   V8CustomButton,
   ConfirmModal,
-  //BackToPrevIcon,
-  //HistoryIcon,
-  //PreviewIcon,
   FormBuilderModal,
   HistoryModal,
   ImportModal,
   CustomInfo,
-  //CardsSwitchIcon,
   PromptModal,
   FormStatusIcon
 } from "@formsflow/components";
-import {
-  convertSelectedValueToMultiSelectOption
-} from "../../../helper/helper";
 import { RESOURCE_BUNDLES_DATA } from "../../../resourceBundles/i18n";
 import LoadingOverlay from "react-loading-overlay-ts";
 import _cloneDeep from "lodash/cloneDeep";
@@ -71,9 +64,9 @@ import { toast } from "react-toastify";
 import userRoles from "../../../constants/permissions.js";
 import {
   generateUniqueId,
-  // textTruncate,
   convertMultiSelectOptionToValue,
-  removeTenantKeywithSlash
+  removeTenantKeywithSlash,
+  convertSelectedValueToMultiSelectOption
 } from "../../../helper/helper.js";
 import { useMutation } from "react-query";
 import NavigateBlocker from "../../../components/CustomComponents/NavigateBlocker";

--- a/forms-flow-web/src/routes/Design/Forms/SettingsTab.js
+++ b/forms-flow-web/src/routes/Design/Forms/SettingsTab.js
@@ -452,10 +452,13 @@ const SettingsTab = (
 };
 
 SettingsTab.propTypes = {
-  show: PropTypes.bool,
-  // handleClose: PropTypes.func.isRequired,
-  handleConfirm: PropTypes.func.isRequired,
-  isSaving: PropTypes.bool,
+  isCreateRoute: PropTypes.bool,
+  rolesState: PropTypes.object,
+  formDetails: PropTypes.object,
+  isAnonymous: PropTypes.bool,
+  setIsAnonymous: PropTypes.func,
+  setFormDetails: PropTypes.func,
+  setRolesState: PropTypes.func,
 };
 
 export default SettingsTab;


### PR DESCRIPTION
# Issue Tracking

JIRA: 
Issue Type:  FEATURE
DEPENDENCY PR : https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/870
# Changes
1. Added form settings tab 
2. Handled formDetails and rolesState in the Form Edit component, so the data will not be lost when switching between tabs on the Form Edit page


TBD :   
- Note in Custom URL: Not added yet.
- Form Name & Path Validation: API is being called, but there’s no UI design to display errors if they occur.
- Save Settings Button: Previously disabled when the multiselect was open and no role was selected.
- DropdownMultiselect CSS: Primary and secondary variant classes are missing.
- SelectDropdown: Outside click functionality is missing.

# Screenshots (if applicable)
<img width="1602" height="866" alt="image" src="https://github.com/user-attachments/assets/ca3b0ad3-db97-45c2-ab97-38f53a944aed" />
<img width="1885" height="860" alt="image" src="https://github.com/user-attachments/assets/2acfb8e2-506d-4c29-a01b-5a64181a17de" />
<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/41d683fe-feed-4b4d-bd67-72cfe3248f42" /> 

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request
