### PR TITLE
FWF-5411: [Bugfix] Block default camunda APIs

### DIFF
--- a/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/keycloak/sso/OAuth2LoginSecurityConfig.java
+++ b/forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/keycloak/sso/OAuth2LoginSecurityConfig.java
@@ -90,7 +90,6 @@ public class OAuth2LoginSecurityConfig  {
 				.securityMatcher(AntPathRequestMatcher.antMatcher("/engine-rest-ext/**"))
 				.authorizeHttpRequests(auth -> auth				 
 						.requestMatchers(
-								antMatcher(HttpMethod.OPTIONS,"/engine-rest/**"),
 								antMatcher(HttpMethod.OPTIONS,"/engine-rest-ext/v1/**"),
 								antMatcher(HttpMethod.OPTIONS, "/forms-flow-bpm-socket/**"),
 								antMatcher(HttpMethod.OPTIONS, "/engine-rest/**"),


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5411
DEPENDENCY PR:
# Changes

- We are exposing Camunda APIs as documented [here](https://aottech.atlassian.net/wiki/spaces/F/pages/2701983745/List+of+Exposed+Camunda+APIs)
 through the base route /camunda/engine-rest-ext/v1.
Currently, if the version (v1) is omitted, all Camunda APIs can still be accessed via /camunda/engine-rest-ext/.
To address this, we plan to block access to all Camunda APIs when accessed without the version — i.e., via /camunda/engine-rest-ext/.
- Block default camunda APIs through `/engine-rest-ext/` and allow only APIs exposed with  `engine-rest-ext/v1/`

# Screenshots

<img width="2337" height="806" alt="image" src="https://github.com/user-attachments/assets/1f8e2a00-7452-40d5-a754-f6df0931d41a" />

**After fix**
<img width="2412" height="730" alt="image" src="https://github.com/user-attachments/assets/1c4bdc8c-6a2c-4538-965e-656d9d1342f6" />

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [X] Added meaningful title for pull request


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Deny unversioned `engine-rest-ext` access

- Permit only `engine-rest-ext/v1/**` routes

- Tighten OPTIONS to versioned endpoint

- Preserve auth for other requests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Security config"] --> B["/engine-rest-ext/v1/** permitted (incl. OPTIONS)"]
  A --> C["/engine-rest-ext/** denied"]
  A --> D["/engine-rest/** OPTIONS permitted"]
  A --> E["Other requests authenticated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OAuth2LoginSecurityConfig.java</strong><dd><code>Enforce versioned Camunda API and deny unversioned</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-bpm/forms-flow-bpm-camunda/src/main/java/org/camunda/bpm/extension/keycloak/sso/OAuth2LoginSecurityConfig.java

<ul><li>Restrict permitAll to <code>/engine-rest-ext/v1/**</code>.<br> <li> Deny all for <code>/engine-rest-ext/**</code> (unversioned).<br> <li> Remove duplicate OPTIONS matchers; keep versioned OPTIONS.<br> <li> Keep OPTIONS for <code>/engine-rest/**</code> and socket paths.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2990/files#diff-a1b9377b84dfcc8d19429288807ac6d4de1e6aa72bebfd3a662657dfb820999f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

