### PR TITLE
initial commit for reusable table

### DIFF
--- a/forms-flow-web/src/components/Form/constants/ClientTable.js
+++ b/forms-flow-web/src/components/Form/constants/ClientTable.js
@@ -1,7 +1,5 @@
-import React, { useState, useCallback } from "react";
+import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { DataGrid } from "@mui/x-data-grid";
-import Paper from "@mui/material/Paper";
 import {
   setClientFormLimit,
   setClientFormListPage,
@@ -11,13 +9,14 @@ import { HelperServices, StyleServices } from "@formsflow/service";
 import { useTranslation } from "react-i18next";
 import {
   V8CustomButton,
-  NewSortDownIcon,
-  RefreshIcon
+  RefreshIcon,
+  ReusableTable
 } from "@formsflow/components";
 import { navigateToFormEntries } from "../../../helper/routerHelper";
 import SubmissionDrafts from "../../../routes/Submit/Forms/DraftAndSubmissions";
 import { fetchBPMFormList } from "../../../apiManager/services/bpmFormServices"; 
-import { setFormSearchLoading } from "../../../actions/checkListActions";  
+import { setFormSearchLoading } from "../../../actions/checkListActions";
+
 
 function ClientTable() {
   const dispatch = useDispatch();
@@ -175,54 +174,20 @@ function ClientTable() {
   const activeField = sortKeyToGridField[activeKey] || activeKey;
   const activeOrder = formsort?.[activeKey]?.sortOrder || "asc";
 
-  const renderDescIcon = useCallback(() => (
-    <div>
-      <NewSortDownIcon color={iconColor} />
-    </div>
-  ), [iconColor]);
-
-  const renderAscIcon = useCallback(() => (
-    <div style={{ transform: "rotate(180deg)" }}>
-      <NewSortDownIcon color={iconColor} />
-    </div>
-  ), [iconColor]);
-
-
   return (
     <>
-      <Paper sx={{ height: { sm: 400, md: 510, lg: 665 }, width: "100%" }}>
-        <DataGrid
-          columns={columns}
-          rows={rows}
-          rowCount={totalForms}
-          loading={searchFormLoading}
-          paginationMode="server"
-          sortingMode="server"
-          disableColumnMenu
-          sortModel={[{ field: activeField, sort: activeOrder }]}
-          onSortModelChange={handleSortChange}
-          paginationModel={paginationModel}
-          onPaginationModelChange={onPaginationModelChange}
-          pageSizeOptions={[10, 25, 50, 100]}
-          rowHeight={55}
-          disableRowSelectionOnClick
-          getRowId={(row) => row.id}
-          slots={{
-            columnSortedDescendingIcon: renderDescIcon,
-            columnSortedAscendingIcon: renderAscIcon,
-          }}
-          slotProps={{
-            loadingOverlay: {
-
-              variant: "skeleton",
-              noRowsVariant: "skeleton",
-            },
-          }}
-          localeText={{
-            noRowsLabel: t("No Forms have been found."),
-          }}
-        />
-      </Paper>
+      <ReusableTable
+        columns={columns}
+        rows={rows}
+        rowCount={totalForms}
+        loading={searchFormLoading}
+        sortModel={[{ field: activeField, sort: activeOrder }]}
+        onSortModelChange={handleSortChange}
+        paginationModel={paginationModel}
+        onPaginationModelChange={onPaginationModelChange}
+        getRowId={(row) => row.id}
+        noRowsLabel={t("No Forms have been found.")}
+      />
       {showSubmissions && <SubmissionDrafts />}
     </>
   );

--- a/forms-flow-web/src/components/Form/constants/FormTable.js
+++ b/forms-flow-web/src/components/Form/constants/FormTable.js
@@ -1,7 +1,5 @@
 import * as React from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { DataGrid } from "@mui/x-data-grid";
-import Paper from "@mui/material/Paper";
 import { useTranslation } from "react-i18next";
 import { push } from "connected-react-router";
 import { setBPMFormLimit, setBPMFormListPage, setBpmFormSort } from "../../../actions/formActions";
@@ -9,9 +7,9 @@ import { resetFormProcessData } from "../../../apiManager/services/processServic
 import { fetchBPMFormList } from "../../../apiManager/services/bpmFormServices";
 import { setFormSearchLoading } from "../../../actions/checkListActions";
 import userRoles from "../../../constants/permissions";
-import { HelperServices,StyleServices } from "@formsflow/service";
+import { HelperServices, StyleServices } from "@formsflow/service";
 import { MULTITENANCY_ENABLED } from "../../../constants/constants";
-import { V8CustomButton,RefreshIcon,NewSortDownIcon,V8CustomDropdownButton } from "@formsflow/components";
+import { V8CustomButton, RefreshIcon, V8CustomDropdownButton, ReusableTable } from "@formsflow/components";
 
 
 function FormTable() {
@@ -186,52 +184,25 @@ const viewOrEditForm = (formId, path) => {
       id: f._id || f.path || f.name,
     })).filter(r => r.id);
   }, [formData]);
+  
   const paginationModel = React.useMemo(
     () => ({ page: pageNo - 1, pageSize: limit }),
     [pageNo, limit]
   );
   
-  
   return (
-    <Paper sx={{ height: {sm: 400, md: 510, lg: 665}, width: "100%" }}>
-      <DataGrid
-        disableColumnResize // disabed resizing
-        columns={columns}
-        rows={rows}
-        rowCount={totalForms}
-        loading={searchFormLoading || isApplicationCountLoading}
-        paginationMode="server"
-        sortingMode="server"
-        disableColumnMenu
-        sortModel={[{ field: activeField, sort: activeOrder }]}
-        onSortModelChange={handleSortChange}
-        paginationModel={paginationModel}
-        getRowId={(row) => row.id}
-        onPaginationModelChange={onPaginationModelChange}
-        pageSizeOptions={[10, 25, 50, 100]}
-        rowHeight={55}
-        disableRowSelectionOnClick
-        slots={{
-          columnSortedDescendingIcon: () => (
-            <div>
-              <NewSortDownIcon color={iconColor} />
-            </div>
-          ),
-          columnSortedAscendingIcon: () => (
-            <div style={{ transform: "rotate(180deg)" }}>
-              <NewSortDownIcon color={iconColor} />
-            </div>
-          ),
-          // columnUnsortedIcon: RefreshIcon,
-        }}
-        slotProps={{
-          loadingOverlay: {
-            variant: 'skeleton',
-            noRowsVariant: 'skeleton',
-          },
-        }}
-      />
-    </Paper>
+    <ReusableTable
+
+      columns={columns}
+      rows={rows}
+      rowCount={totalForms}
+      loading={searchFormLoading || isApplicationCountLoading}
+      sortModel={[{ field: activeField, sort: activeOrder }]}
+      onSortModelChange={handleSortChange}
+      paginationModel={paginationModel}
+      onPaginationModelChange={onPaginationModelChange}
+      getRowId={(row) => row.id}
+    />
   );
 }
 

--- a/forms-flow-web/src/components/Form/constants/SubmissionsAndDraftTable.js
+++ b/forms-flow-web/src/components/Form/constants/SubmissionsAndDraftTable.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useCallback} from "react";
+import React, {useState, useEffect} from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { selectRoot } from "@aot-technologies/formio-react";
 import { CLIENT_EDIT_STATUS } from "../../../constants/applicationConstants";
@@ -8,17 +8,16 @@ import {
     setFormSubmissionSort,
 } from "../../../actions/applicationActions";
 import { useTranslation } from "react-i18next";
-import { PromptModal, V8CustomButton, NewSortDownIcon, RefreshIcon } from "@formsflow/components";
+import { PromptModal, V8CustomButton, RefreshIcon, ReusableTable } from "@formsflow/components";
 import { toast } from "react-toastify";
 import { deleteDraftbyId } from "../../../apiManager/services/draftService";
 import { navigateToDraftEdit, navigateToViewSubmission, navigateToResubmit } from "../../../helper/routerHelper";
 import PropTypes from "prop-types";
 import { HelperServices, StyleServices } from "@formsflow/service";
-import { DataGrid } from "@mui/x-data-grid";
-import Paper from "@mui/material/Paper";
 
 const SubmissionsAndDraftTable = ({ fetchSubmissionsAndDrafts }) => {
     const tenantKey = useSelector((state) => state.tenants?.tenantId);
+    const iconColor = StyleServices.getCSSVariable("--ff-gray-medium-dark");
     const dispatch = useDispatch();
     const { t } = useTranslation();
     const {
@@ -38,7 +37,6 @@ const SubmissionsAndDraftTable = ({ fetchSubmissionsAndDrafts }) => {
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [deleteDraftId, setDeleteDraftId] = useState('');
     const [isDeletionLoading, setIsDeletionLoading] = useState(false);
-    const iconColor = StyleServices.getCSSVariable("--ff-gray-medium-dark");
 
   const gridFieldToSortKey = {
     id: "id",
@@ -244,38 +242,21 @@ const SubmissionsAndDraftTable = ({ fetchSubmissionsAndDrafts }) => {
   const activeField = sortKeyToGridField[activeKey] || activeKey;
   const activeOrder = applicationSort?.[activeKey]?.sortOrder || "asc";
 
-    const renderDescIcon = useCallback(() => (
-      <div>
-        <NewSortDownIcon color={iconColor} />
-      </div>
-    ), [iconColor]);
-  
-    const renderAscIcon = useCallback(() => (
-      <div style={{ transform: "rotate(180deg)" }}>
-        <NewSortDownIcon color={iconColor} />
-      </div>
-    ), [iconColor]);
-
   return (
     <>
-      <Paper sx={{ height: { sm: 400, md: 510, lg: 665 }, width: "100%" }}>
-        <DataGrid
-          columns={columns}
-          rows={rows}
-          rowCount={totalForms}
-          loading={isApplicationLoading || searchFormLoading}
-          paginationMode="server"
-          sortingMode="server"
-          disableColumnMenu
-          sortModel={[{ field: activeField, sort: activeOrder }]}
-          onSortModelChange={handleSortChange}
-          paginationModel={paginationModel}
-          onPaginationModelChange={onPaginationModelChange}
-          pageSizeOptions={[10, 25, 50, 100]}
-          rowHeight={55}
-          disableRowSelectionOnClick
-          getRowId={(row) => row.id}
-          sx={{
+      <ReusableTable
+        columns={columns}
+        rows={rows}
+        rowCount={totalForms}
+        loading={isApplicationLoading || searchFormLoading}
+        sortModel={[{ field: activeField, sort: activeOrder }]}
+        onSortModelChange={handleSortChange}
+        paginationModel={paginationModel}
+        onPaginationModelChange={onPaginationModelChange}
+        getRowId={(row) => row.id}
+        noRowsLabel={t("No Entries have been found.")}
+        dataGridProps={{
+          sx: {
             "& .MuiDataGrid-columnHeader--sortable": {
               "& .MuiDataGrid-iconButtonContainer": {
                 visibility: "visible",
@@ -284,22 +265,9 @@ const SubmissionsAndDraftTable = ({ fetchSubmissionsAndDrafts }) => {
                 opacity: 0.3,
               },
             },
-          }}
-          slots={{
-            columnSortedDescendingIcon: renderDescIcon,
-            columnSortedAscendingIcon: renderAscIcon,
-          }}
-          slotProps={{
-            loadingOverlay: {
-              variant: "skeleton",
-              noRowsVariant: "skeleton",
-            },
-          }}
-          localeText={{
-            noRowsLabel: t("No Entries have been found."),
-          }}
-        />
-      </Paper>
+          },
+        }}
+      />
       <PromptModal
         show={showDeleteModal}
         onClose={handleCloseActionModal}

--- a/forms-flow-web/src/routes/Design/Process/ProcessTable.js
+++ b/forms-flow-web/src/routes/Design/Process/ProcessTable.js
@@ -6,12 +6,9 @@ import {
   V8CustomDropdownButton,
   BuildModal,
   RefreshIcon,
-  NewSortDownIcon,
-
+  ReusableTable
 } from "@formsflow/components";
 import { useTranslation } from "react-i18next";
-import { DataGrid } from '@mui/x-data-grid';
-import Paper from "@mui/material/Paper";
 import { useParams } from "react-router-dom";
 import { fetchAllProcesses } from "../../../apiManager/services/processServices";
 import { MULTITENANCY_ENABLED } from "../../../constants/constants";
@@ -25,7 +22,7 @@ import {
   setDmnSort
 } from "../../../actions/processActions";
 import userRoles from "../../../constants/permissions";
-import { HelperServices,StyleServices } from "@formsflow/service";
+import { HelperServices, StyleServices } from "@formsflow/service";
 import {
   navigateToSubflowBuild,
   navigateToDecisionTableBuild,
@@ -358,50 +355,23 @@ const ProcessTable = React.memo(() => {
           />
         </div>
       </div>
-      <Paper sx={{ height: { sm: 400, md: 510, lg: 510 }, width: "100%" }}>
-        <DataGrid
-          disableColumnResize // disabed resizing
-          columns={columns}
-          rows={processList}
-          rowCount={totalCount}
-          loading={searchLoading || isLoading}
-          paginationMode="server"
-          sortingMode="server"
-          disableColumnMenu
-          sortModel={[
-            {
-              field: sortConfig.activeKey,
-              sort: sortConfig[sortConfig.activeKey].sortOrder,
-            },
-          ]}
-          onSortModelChange={handleSort}
-          paginationModel={paginationModel}
-          getRowId={(row) => row.id}
-          onPaginationModelChange={onPaginationModelChange}
-          pageSizeOptions={[10, 25, 50, 100]}
-          rowHeight={55}
-          disableRowSelectionOnClick
-          slots={{
-            columnSortedDescendingIcon: () => (
-              <div>
-                <NewSortDownIcon color={iconColor} />
-              </div>
-            ),
-            columnSortedAscendingIcon: () => (
-              <div style={{ transform: "rotate(180deg)" }}>
-                <NewSortDownIcon color={iconColor} />
-              </div>
-            ),
-            // columnUnsortedIcon: RefreshIcon,
-          }}
-          slotProps={{
-            loadingOverlay: {
-              variant: "skeleton",
-              noRowsVariant: "skeleton",
-            },
-          }}
-        />
-      </Paper>
+      <ReusableTable
+        columns={columns}
+        rows={processList}
+        rowCount={totalCount}
+        loading={searchLoading || isLoading}
+        sortModel={[
+          {
+            field: sortConfig.activeKey,
+            sort: sortConfig[sortConfig.activeKey].sortOrder,
+          },
+        ]}
+        onSortModelChange={handleSort}
+        paginationModel={paginationModel}
+        onPaginationModelChange={onPaginationModelChange}
+        getRowId={(row) => row.id}
+        sx={{ height: { sm: 400, md: 510, lg: 510 }, width: "100%" }}
+      />
 
       <BuildModal
         show={showBuildModal}

--- a/forms-flow-web/src/routes/Submit/Submission/SubmissionView.js
+++ b/forms-flow-web/src/routes/Submit/Submission/SubmissionView.js
@@ -1,8 +1,6 @@
 import React, { useEffect, useState, useMemo } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import { DataGrid } from "@mui/x-data-grid";
-import Paper from "@mui/material/Paper";
 import {
   FormSubmissionHistoryModal,
   SubmissionHistoryWithViewButton,
@@ -11,6 +9,7 @@ import {
   BreadCrumbs,
   BreadcrumbVariant,
   RefreshIcon,
+  ReusableTable
 } from "@formsflow/components";
 import { getApplicationById } from "../../../apiManager/services/applicationServices";
 import Loading from "../../../containers/Loading";
@@ -80,24 +79,15 @@ const HistoryDataGrid = ({ historyData, onRefresh, iconColor, loading }) => {
   const rows = historyData || [];
 
   return (
-   <Paper sx={{ height: { sm: 400, md: 510, lg: 665 }, width: "100%" }}>
-      <DataGrid
-        rows={rows}
-        columns={columns}
-        loading={loading}
-        getRowId={(row) => row.submissionId || `${row.formId}-${row.created}`}
-        disableColumnMenu 
-        localeText={{
-          noRowsLabel: t("No history found"),
-        }}
-        slotProps={{
-          loadingOverlay: {
-            variant: "skeleton",
-            noRowsVariant: "skeleton",
-          },
-        }}
-      />
-    </Paper>
+    <ReusableTable
+      rows={rows}
+      columns={columns}
+      loading={loading}
+      getRowId={(row) => row.submissionId || `${row.formId}-${row.created}`}
+      noRowsLabel={t("No history found")}
+      paginationMode="client"
+      sortingMode="client"
+    />
   );
 };
 


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5458
DEPENDENCY PR:
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->

# Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

# Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->

# Checklist
- [ ] Updated changelog
- [ ] Added meaningful title for pull request


___

### **PR Type**
Enhancement


___

### **Description**
- Replace DataGrid with ReusableTable

- Remove custom sort icons logic

- Preserve server-side sorting/pagination

- Standardize no-rows labels and styles


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MUI["MUI DataGrid usage"] -- replaced by --> RT["ReusableTable component"]
  CustomIcons["Custom sort icons"] -- removed --> RT
  PerPageLogic["Local pagination/sort props"] -- preserved --> RT
  LabelsStyles["No-rows labels and styles"] -- unified via --> RT
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClientTable.js</strong><dd><code>Client table migrated to ReusableTable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/constants/ClientTable.js

<ul><li>Replace MUI DataGrid and Paper with ReusableTable<br> <li> Remove custom sort icon renderers<br> <li> Pass server-side sort/pagination and no-rows label<br> <li> Keep existing handlers and row id logic</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2996/files#diff-23e1bd11bd91d1eeda9eabda1f72083be802a29a8dd2d50e93aab8ce3c61e87f">+17/-52</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FormTable.js</strong><dd><code>Form table switched to ReusableTable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/constants/FormTable.js

<ul><li>Swap DataGrid/Paper for ReusableTable<br> <li> Remove sort icon slots and loading overlay props<br> <li> Preserve server-side sort/pagination and getRowId</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2996/files#diff-b74eebc5e24b825c00b858b2a650cde1538951dbeb5e645e680e573495c1b00a">+15/-44</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SubmissionsAndDraftTable.js</strong><dd><code>Submissions/drafts table uses ReusableTable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/constants/SubmissionsAndDraftTable.js

<ul><li>Replace DataGrid/Paper with ReusableTable<br> <li> Remove useCallback sort icon renderers<br> <li> Provide no-rows label and pass custom sx via dataGridProps<br> <li> Retain server-side sort/pagination and row id</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2996/files#diff-96a8076e8c62f285624cb3a4caebb5c00e21f16f1dd2e6ab5d4b679d86b795ae">+19/-51</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ProcessTable.js</strong><dd><code>Process table migrated to ReusableTable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Process/ProcessTable.js

<ul><li>Replace DataGrid/Paper with ReusableTable<br> <li> Maintain sort model and pagination handlers<br> <li> Remove custom sort icon slots and overlays<br> <li> Apply sizing via sx on ReusableTable</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2996/files#diff-0aed91dcd745d48207ead71039a11119797ab8948221d8a0e030dd752643b873">+19/-49</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SubmissionView.js</strong><dd><code>Submission history uses ReusableTable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Submit/Submission/SubmissionView.js

<ul><li>Use ReusableTable for submission history<br> <li> Remove Paper/DataGrid and overlays<br> <li> Set client-side pagination/sorting and no-rows label</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/2996/files#diff-9c7ef058765137bdc8e30fd68f694d8a0a585709e326766b8de274fa647bd845">+10/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

