### PR TITLE
feature/fwf-5574:Updated variable selection ui

### DIFF
--- a/forms-flow-web/src/routes/Design/Forms/FormEdit.js
+++ b/forms-flow-web/src/routes/Design/Forms/FormEdit.js
@@ -1197,6 +1197,24 @@ const handleSaveLayout = () => {
     t,
     hasSavedFormVariablesChanged,
   ]);
+
+  // saving the form variables to the state
+  useEffect(() => {
+    const updatedLabels = {};
+    // Add taskVariables to updatedLabels
+    formProcessList?.taskVariables?.forEach(({ key, label, type }) => {
+      updatedLabels[key] = {
+        key,
+        altVariable: label, // Use label from taskVariables as altVariable
+        labelOfComponent: label, // Set the same label for labelOfComponent
+        type: type,
+      };
+    });
+    setSavedFormVariables(updatedLabels);
+    // Store initial state for change detection
+    initialSavedFormVariablesRef.current = structuredClone(updatedLabels);
+  }, [formProcessList]);
+
   const saveFormData = async ({ showToast = true }) => {
     try {
       const isFormChanged = true; // Hard code the value to always make backend call on Save Layout
@@ -1354,7 +1372,7 @@ const handleSaveLayout = () => {
       setPromptNewVersion(false);
       setFormChangeState(prev => ({ ...prev, changed: false }));
       // Update initial savedFormVariables reference after successful save
-      initialSavedFormVariablesRef.current = JSON.parse(JSON.stringify(savedFormVariables));
+      initialSavedFormVariablesRef.current = structuredClone(savedFormVariables);
     } catch (err) {
       const error = err.response?.data || err.message;
       dispatch(setFormFailureErrorData("form", error));
@@ -1496,7 +1514,7 @@ const saveFormWithWorkflow = async (publishAfterSave = false) => {
     setFormChangeState({ initial: false, changed: false });
     setWorkflowIsChanged(false);
     // Update initial savedFormVariables reference after successful save
-    initialSavedFormVariablesRef.current = JSON.parse(JSON.stringify(savedFormVariables));
+    initialSavedFormVariablesRef.current = structuredClone(savedFormVariables);
     setSettingsChanged(false);
     setIsFormSettingsChanged(false);
     isNavigatingAfterSaveRef.current = true;
@@ -2256,23 +2274,6 @@ const saveFormWithWorkflow = async (publishAfterSave = false) => {
       }
     }
   };
-
-  // saving the form variables to the state
-  useEffect(() => {
-    const updatedLabels = {};
-    // Add taskVariables to updatedLabels
-    formProcessList?.taskVariables?.forEach(({ key, label, type }) => {
-      updatedLabels[key] = {
-        key,
-        altVariable: label, // Use label from taskVariables as altVariable
-        labelOfComponent: label, // Set the same label for labelOfComponent
-        type: type,
-      };
-    });
-    setSavedFormVariables(updatedLabels);
-    // Store initial state for change detection
-    initialSavedFormVariablesRef.current = JSON.parse(JSON.stringify(updatedLabels));
-  }, [formProcessList]);
 
   // Render tab content based on active tab
   const renderTabContent = () => {


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
 Chnaged ui for variable selection 
handle disabled scenario in create and edit routes

**Related Jira Ticket:**  


**DEPENDENCY PR:**  
<!-- Dependency Ticket link like this format - https://github.com/AOT-Technologies/forms-flow-ai/pull/3012 -->

**Type of Change:**
- [x] ✨ Feature
- [ ] 🐞 Bug Fix
- [x] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 🔄 SYNC PR (for syncing different repos)
- [ ] 📦 Dependency / Package Updates
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config Change / Yaml changes

---

## 💻 Frontend Changes 

**Modules/Components Affected:**
<!-- List key components, pages, or hooks modified. -->

**Summary of Frontend Changes:**
<!-- Describe UI/UX or logic updates. -->

**UI/UX Review:**
- [x] Required
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings for UI changes. -->

---

## ⚙️ Backend Changes (Java / Python)

**Modules/Endpoints Affected:**
<!-- List controllers, services, or APIs modified. -->

**Summary of Backend Changes:**
<!-- Describe logic changes, data model updates, or new APIs added. -->

**API Testing:**
- [ ] Done
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings . -->

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated [Backend]
- [ ] UI verified [Frontend]   
- [ ] Documentation updated (README / Confluence / API Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [ ] I have given a **clear and meaningful PR title and description as per standard format**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  



**Details:**
<!-- Add additional details if any of the above boxes are checked.[optional] -->

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add variables state and change tracking

- Integrate VariableSelection with saved variables

- Include taskVariables in mapper payload

- Disable variables UI on create/unsaved/published


___

### Diagram Walkthrough


```mermaid
flowchart LR
  UI["VariableSelection UI"] -- "onChange(savedFormVariables)" --> State["savedFormVariables state"]
  State -- "change detection" --> SaveBtn["Save enabled/disabled"]
  State -- "build taskVariables" --> Mapper["Save mapper payload"]
  SaveAction["Save/Publish"] -- "POST" --> Backend["Process/Form APIs"]
  SaveAction -- "on success" --> InitialRef["Update initial variables ref"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormEdit.js</strong><dd><code>Persistable variable mapping with UI integration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Forms/FormEdit.js

<ul><li>Track <code>savedFormVariables</code> with initial ref.<br> <li> Enable Save when variables change.<br> <li> Populate from <code>formProcessList.taskVariables</code>.<br> <li> Persist as <code>mapper.taskVariables</code> on save.<br> <li> Replace variables tab with unified <code>VariableSelection</code> component.<br> <li> Disable variables tab on create and when unsaved/published.<br> <li> Remove legacy system variables grid and handlers.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3042/files#diff-77e52510df04afdc123ea687d48b039915d6dd1b0596d6557e522dad575f8b1a">+89/-110</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

