### PR TITLE
bugfix/fwf-5658:Fixed unsaved modal issue

### DIFF
--- a/forms-flow-web/src/helper/helper.js
+++ b/forms-flow-web/src/helper/helper.js
@@ -103,6 +103,31 @@ const addTenantkeyAsSuffix = (value, tenantkey) => {
     return `${value.toLowerCase()}${tenantkey}-`;
   }
 };
+// Helper function to compare roles state without considering unique IDs
+const compareRolesState = (roles1, roles2, key = null) => {
+  if (!roles1 || !roles2) return false;
+  
+  // Compare each section (DESIGN, FORM, APPLICATION)
+  const sections = ['DESIGN', 'FORM', 'APPLICATION'];
+  return sections.every(section => {
+    const section1 = roles1[section];
+    const section2 = roles2[section];
+    
+    if (!section1 || !section2) return false;
+    
+    // Compare selectedOption
+    if (section1.selectedOption !== section2.selectedOption) return false;
+    
+    // Compare roleInput (if exists)
+    if (section1.roleInput !== section2.roleInput) return false;
+    
+    // Compare selectedRoles by extracting only the role values (ignoring IDs)
+    const roles1Values = (section1.selectedRoles || []).map(r => r[key]).sort();
+    const roles2Values = (section2.selectedRoles || []).map(r => r[key]).sort();
+    
+    return _.isEqual(roles1Values, roles2Values);
+  });
+};
 
 /* ----------------- convert data from and into multiselect ----------------- */
 const convertMultiSelectOptionToValue = (selectedValues = [], key = null) => 
@@ -122,5 +147,6 @@ export { generateUniqueId,
   isFormComponentsChanged,
   addTenantkeyAsSuffix, 
   convertMultiSelectOptionToValue,
-  convertSelectedValueToMultiSelectOption
+  convertSelectedValueToMultiSelectOption,
+  compareRolesState
 };


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
1. fixed unsaved modal appear After a successful save
2. added save functionality in save button of modal

**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-5658

**DEPENDENCY PR:**  
<!-- Dependency Ticket link like this format - https://github.com/AOT-Technologies/forms-flow-ai/pull/3012 -->

**Type of Change:**
- [ ] ✨ Feature
- [ ] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 🔄 SYNC PR (for syncing different repos)
- [ ] 📦 Dependency / Package Updates
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config Change / Yaml changes

---

## 💻 Frontend Changes 

**Modules/Components Affected:**
<!-- List key components, pages, or hooks modified. -->

**Summary of Frontend Changes:**
<!-- Describe UI/UX or logic updates. -->

**UI/UX Review:**
- [ ] Required
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings for UI changes. -->

---

## ⚙️ Backend Changes (Java / Python)

**Modules/Endpoints Affected:**
<!-- List controllers, services, or APIs modified. -->

**Summary of Backend Changes:**
<!-- Describe logic changes, data model updates, or new APIs added. -->

**API Testing:**
- [ ] Done
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<img width="1770" height="854" alt="image" src="https://github.com/user-attachments/assets/7d5ddafd-f910-47fe-88d6-efa3f757c21a" />

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated [Backend]
- [x] UI verified [Frontend]   
- [ ] Documentation updated (README / Confluence / API Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description as per standard format**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  



**Details:**
<!-- Add additional details if any of the above boxes are checked.[optional] -->

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers. -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix unsaved‐changes modal save action
  - Add `onSave` handler to NavigateBlocker

- Add `compareRolesState` to ignore IDs in diff

- Update FormEdit initial states after save

- Ensure roles/form/isAnonymous tracked correctly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User edits form"] --> B["Track changes via compareRolesState"]
  B --> C["NavigateBlocker prompts on navigation"]
  C -- "Save" --> D["handleSaveFromBlocker"]
  D --> E["saveFormData or saveFormWithWorkflow"]
  E --> F["Update initial form, roles, isAnonymous"]
  F --> G["Allow navigation"]
  C -- "Discard" --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helper.js</strong><dd><code>Add roles state comparison helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/helper/helper.js

<ul><li>Introduce <code>compareRolesState</code> helper<br> <li> Compare roles ignoring unique IDs<br> <li> Export new utility in helper module</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3049/files#diff-cbf77ae13133f22b4577b70ac05ee538f56024a74459f695a162b6b0bc91824c">+27/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NavigateBlocker.jsx</strong><dd><code>Enhance NavigateBlocker save handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/CustomComponents/NavigateBlocker.jsx

<ul><li>Accept <code>onSave</code> prop for save callback<br> <li> Add <code>isSaving</code> state and <code>handleSave</code><br> <li> Show loading indicators on save button<br> <li> Allow navigation after save success</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3049/files#diff-91f66b1b4b4d4c5d33735bc5f1d4fbbf653384d138a9642caf5515e32ab4bb80">+24/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormEdit.js</strong><dd><code>Integrate roles diff and modal save</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Forms/FormEdit.js

<ul><li>Use <code>compareRolesState</code> for dirty checking<br> <li> Add <code>handleSaveFromBlocker</code> for modal saves<br> <li> Update initial form/roles/isAnonymous after save<br> <li> Pass <code>onSave</code> to NavigateBlocker</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3049/files#diff-77e52510df04afdc123ea687d48b039915d6dd1b0596d6557e522dad575f8b1a">+54/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

