### PR TITLE
FWF-5692 [bugfix] fixed the save enabled issue

### DIFF
--- a/forms-flow-web/src/routes/Design/Forms/FlowEdit.js
+++ b/forms-flow-web/src/routes/Design/Forms/FlowEdit.js
@@ -235,6 +235,8 @@ const enableWorkflowChange = async () => {
         });
         dispatch(setProcessData(response.data));
         disableWorkflowChange();
+        // Update the current BPMN XML baseline to the saved XML
+        setCurrentBpmnXml(xml);
         isReverted && setIsReverted(!isReverted); //if it already reverted the need to make it false
         showToast && toast.success(t("Process updated successfully"));
       } catch (error) {


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
fixed enabled condition issue
not fixed the settings modal refresh case will check later
published text in create route fixed
**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-5692
**DEPENDENCY PR:**  
<!-- Dependency Ticket link like this format - https://github.com/AOT-Technologies/forms-flow-ai/pull/3012 -->

**Type of Change:**
- [ ] ✨ Feature
- [ ] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 🔄 SYNC PR (for syncing different repos)
- [ ] 📦 Dependency / Package Updates
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config Change / Yaml changes

---

## 💻 Frontend Changes 

**Modules/Components Affected:**
<!-- List key components, pages, or hooks modified. -->

**Summary of Frontend Changes:**
<!-- Describe UI/UX or logic updates. -->

**UI/UX Review:**
- [ ] Required
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings for UI changes. -->

---

## ⚙️ Backend Changes (Java / Python)

**Modules/Endpoints Affected:**
<!-- List controllers, services, or APIs modified. -->

**Summary of Backend Changes:**
<!-- Describe logic changes, data model updates, or new APIs added. -->

**API Testing:**
- [ ] Done
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings . -->

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated [Backend]
- [ ] UI verified [Frontend]   
- [ ] Documentation updated (README / Confluence / API Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [ ] I have given a **clear and meaningful PR title and description as per standard format**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  



**Details:**
<!-- Add additional details if any of the above boxes are checked.[optional] -->

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers. -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix save button enablement logic

- Sync BPMN baseline after save

- Correct publish state on route change

- Add precise discard behavior per tab


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SaveBtn["Save enablement logic"] -- "use settingsChanged" --> FormEdit["FormEdit.js"]
  PublishState["Publish state handling"] -- "reset on route/status" --> FormEdit
  BPMNBaseline["BPMN XML baseline"] -- "set after save" --> FlowEdit["FlowEdit.js"]
  DiscardFlows["Discard logic per tab"] -- "form/bpmn/variables" --> FormEdit
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FlowEdit.js</strong><dd><code>Sync BPMN baseline after process save</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Forms/FlowEdit.js

<ul><li>Update BPMN baseline after successful process update.<br> <li> Keep workflow revert flag consistent.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3058/files#diff-d95599c421f12c7a01b4b740713077226216a80b155bbcd732abffdd3465a52a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormEdit.js</strong><dd><code>Fix save logic and discard/publish behaviors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Forms/FormEdit.js

<ul><li>Remove redundant settings diff tracking; use settingsChanged.<br> <li> Reset publish state on route/status changes.<br> <li> Update local form state immediately after save.<br> <li> Refine discard actions per active tab, incl. variables.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3058/files#diff-77e52510df04afdc123ea687d48b039915d6dd1b0596d6557e522dad575f8b1a">+79/-39</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

