### PR TITLE
FWF-5737 [BUGFIX] - Issue fixes in the Subflow

### DIFF
--- a/forms-flow-web/src/routes/Design/Process/ProcessTable.js
+++ b/forms-flow-web/src/routes/Design/Process/ProcessTable.js
@@ -135,6 +135,7 @@ const ProcessTable = React.memo(() => {
   }, [dispatch, pageNo, limit, tenantKey, reduxSearch, sortBy, sortOrder, isBPMN]);
 
   const handleRefresh = () => {
+    setSearchLoading(true);
     dispatch(
       fetchAllProcesses(
         {
@@ -186,8 +187,10 @@ const ProcessTable = React.memo(() => {
       dispatch(setDmnSort(newSortConfig));
     }
   }, [dispatch, isBPMN, sortConfig]);
-  const handleSearch = () => {
+  
+  const handleSearch = useCallback(() => {
     setSearchLoading(true);
+    const searchValue = isBPMN ? searchBPMN : searchDMN;
     batch(() => {
       if (isBPMN) {
         dispatch(setBpmnSearchText(searchBPMN));
@@ -197,7 +200,24 @@ const ProcessTable = React.memo(() => {
         dispatch(setDmnPage(1));
       }
     });
-  };
+    dispatch(
+      fetchAllProcesses(
+        {
+          pageNo: 1,
+          tenant_key: tenantKey,
+          processType: ProcessContents.processType,
+          limit,
+          searchKey: searchValue,
+          sortBy,
+          sortOrder,
+        },
+        () => {
+          setSearchLoading(false);
+        }
+      )
+    );
+  }, [dispatch, isBPMN, searchBPMN, searchDMN, tenantKey, limit,
+    sortBy, sortOrder, ProcessContents.processType]);
 
   const handlePageChange = useCallback((page) => {
     if (isBPMN) {
@@ -464,18 +484,18 @@ const ProcessTable = React.memo(() => {
         </div>
       </div>
       <div className="body-section">
-      <ReusableTable
-        columns={columns}
-        rows={processList}
-        rowCount={totalCount}
-        loading={searchLoading || isProcessLoading}
-        sortModel={sortModel}
-        onSortModelChange={handleSort}
-        paginationModel={paginationModel}
-        onPaginationModelChange={onPaginationModelChange}
-        getRowId={(row) => row.id}
-        autoHeight={true}
-      />
+        <ReusableTable
+          columns={columns}
+          rows={processList}
+          rowCount={totalCount}
+          loading={searchLoading || isProcessLoading}
+          sortModel={sortModel}
+          onSortModelChange={handleSort}
+          paginationModel={paginationModel}
+          onPaginationModelChange={onPaginationModelChange}
+          getRowId={(row) => row.id}
+          autoHeight={true}
+        />
       </div>
       <BuildModal
         show={showBuildModal}


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
Refresh button issue and search on same text not loading

**Related Jira Ticket:**  
[https://aottech.atlassian.net/browse/FWF-5737](https://aottech.atlassian.net/browse/FWF-5737)

**DEPENDENCY PR:**  
No

**Type of Change:**
- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 🔄 SYNC PR (for syncing different repos)
- [ ] 📦 Dependency / Package Updates
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config Change / Yaml changes

---

## 💻 Frontend Changes 

**Modules/Components Affected:**
- forms-flow-web/src/routes/Design/Process/ProcessTable.js

**Summary of Frontend Changes:**
Refresh button issue fixed and the dispatch works on repeat search

**UI/UX Review:**
- [x] Required
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings for UI changes. -->

---

## ⚙️ Backend Changes (Java / Python)

**Modules/Endpoints Affected:**
<!-- List controllers, services, or APIs modified. -->

**Summary of Backend Changes:**
<!-- Describe logic changes, data model updates, or new APIs added. -->

**API Testing:**
- [ ] Done
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings . -->

## ✅ Checklist

- [x] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated [Backend]
- [x] UI verified [Frontend]   
- [ ] Documentation updated (README / Confluence / API Docs)  
- [x] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description as per standard format**  
- [x] I have verified **cross-repo dependencies** (if any)  
- [x] I have confirmed **backward compatibility** with previous releases  



**Details:**
<!-- Add additional details if any of the above boxes are checked.[optional] -->

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fix refresh sets loading state

- Make search dispatch on same text

- Trigger fetch on search action

- Memoize search handler with dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  RefreshBtn["Refresh button click"] -- setSearchLoading(true) --> LoadingState["Loading spinner shown"]
  RefreshBtn -- dispatch fetchAllProcesses --> FetchCall["API fetchAllProcesses"]
  SearchBtn["Search action"] -- memoized handleSearch --> SearchHandler["Compute search value"]
  SearchHandler -- dispatch set*SearchText & set*Page(1) --> ReduxUpdates["Redux search/page updated"]
  SearchHandler -- dispatch fetchAllProcesses --> FetchCall
  FetchCall -- callback --> LoadingStateEnd["setSearchLoading(false)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProcessTable.js</strong><dd><code>Improve refresh/search flow and memoize handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Process/ProcessTable.js

<ul><li>Set <code>setSearchLoading(true)</code> in <code>handleRefresh</code>.<br> <li> Convert <code>handleSearch</code> to <code>useCallback</code> with deps.<br> <li> Compute <code>searchValue</code> and dispatch immediate fetch.<br> <li> Minor indentation/formatting in <code>ReusableTable</code> block.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3070/files#diff-0aed91dcd745d48207ead71039a11119797ab8948221d8a0e030dd752643b873">+34/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

