### PR TITLE
FWF-5750 [FEATURE] - Form and system tabs switched

### DIFF
--- a/forms-flow-web/src/routes/Design/Forms/FormEdit.js
+++ b/forms-flow-web/src/routes/Design/Forms/FormEdit.js
@@ -156,14 +156,14 @@ const tabConfig = {
           label: "Variables",
           query: "?tab=bpmn&sub=variables",
           tertiary: {
+            form: {
+              label: "Form",
+              query: "?tab=bpmn&sub=variables&subsub=form"
+            },
             system: {
               label: "System",
               query: "?tab=bpmn&sub=variables&subsub=system"
             },
-            form: {
-              label: "Form",
-              query: "?tab=bpmn&sub=variables&subsub=form"
-            }
           }
         }
       }
@@ -867,7 +867,7 @@ useEffect(() => {
   let subsub = queryParams.get("subsub");
 
   if (tab === 'bpmn' && sub === 'variables' && subsub === null) {
-    subsub = 'system';
+    subsub = 'form';
   }
 
   let secondaryTab = sub;
@@ -911,7 +911,7 @@ useEffect(() => {
   const handleTabClick = async (primary, secondary = null, tertiary = null) => {
     // Allow BPMN tab on create route
     if (primary === 'bpmn' && secondary === 'variables' && tertiary === null) {
-      tertiary = 'system';
+      tertiary = 'form';
     }
   
     // CAPTURE CURRENT BPMN XML BEFORE SWITCHING AWAY FROM BPMN TAB


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
Switch the position of the Form and System tabs in the form builder page

**Related Jira Ticket:**  
[https://aottech.atlassian.net/browse/FWF-5750](https://aottech.atlassian.net/browse/FWF-5750)

**DEPENDENCY PR:**  
NIL

**Type of Change:**
- [x] ✨ Feature
- [ ] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 🔄 SYNC PR (for syncing different repos)
- [ ] 📦 Dependency / Package Updates
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config Change / Yaml changes

---

## 💻 Frontend Changes 

**Modules/Components Affected:**
- forms-flow-web/src/routes/Design/Forms/FormEdit.js

**Summary of Frontend Changes:**
Tab positions switched

**UI/UX Review:**
- [x] Required
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
Before:
<img width="541" height="281" alt="image" src="https://github.com/user-attachments/assets/5f4ee81c-f91f-4f1e-8a3f-86883a0af239" />


After:
<img width="526" height="307" alt="image" src="https://github.com/user-attachments/assets/94b9df0f-1dce-434d-b1fc-bc8f1c39ae15" />


---

## ⚙️ Backend Changes (Java / Python)

**Modules/Endpoints Affected:**
<!-- List controllers, services, or APIs modified. -->

**Summary of Backend Changes:**
<!-- Describe logic changes, data model updates, or new APIs added. -->

**API Testing:**
- [ ] Done
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings . -->

## ✅ Checklist

- [x] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated [Backend]
- [x] UI verified [Frontend]   
- [ ] Documentation updated (README / Confluence / API Docs)  
- [x] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description as per standard format**  
- [x] I have verified **cross-repo dependencies** (if any)  
- [x] I have confirmed **backward compatibility** with previous releases  



**Details:**
<!-- Add additional details if any of the above boxes are checked.[optional] -->

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Default variable subtab set to Form

- Reorder tertiary tabs: Form before System

- Update tab click fallback to Form

- Align query params with new order


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Variables tertiary tabs"] -- "reordered" --> B["Form first, then System"]
  C["Default subsub resolution"] -- "no subsub" --> D["Defaults to Form"]
  E["Tab click handler"] -- "fallback tertiary" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormEdit.js</strong><dd><code>Make Form the default and first tertiary tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/routes/Design/Forms/FormEdit.js

<ul><li>Reordered <code>tertiary</code> tabs: <code>form</code> before <code>system</code>.<br> <li> Default <code>subsub</code> switched from <code>system</code> to <code>form</code>.<br> <li> Tab click handler default <code>tertiary</code> set to <code>form</code>.<br> <li> Preserves existing labels and queries elsewhere.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3071/files#diff-77e52510df04afdc123ea687d48b039915d6dd1b0596d6557e522dad575f8b1a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

