### PR TITLE
FWF-5886[bugfix] - included validate API in builder API

### DIFF
--- a/forms-flow-api/tests/unit/api/test_form_process_mapper.py
+++ b/forms-flow-api/tests/unit/api/test_form_process_mapper.py
@@ -1170,9 +1170,11 @@ def test_form_flow_builder_update_invalid_payload(app, client, session, jwt, moc
 # Test cases for validation changes in form-flow-builder endpoints
 # ---------------------------------------------------------------------
 
+
 def test_form_flow_builder_post_with_title_path_validation_success(
     app, client, session, jwt, mock_redis_client
 ):
+    """Testing POST /form/form-flow-builder with title and path validation - success case."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1196,6 +1198,7 @@ def test_form_flow_builder_post_with_title_path_validation_success(
 def test_form_flow_builder_post_with_title_path_validation_failure(
     app, client, session, jwt, mock_redis_client
 ):
+    """Testing POST /form/form-flow-builder with title and path validation - failure case (duplicate)."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1220,6 +1223,7 @@ def test_form_flow_builder_post_with_title_path_validation_failure(
 def test_form_flow_builder_post_with_title_only_validation(
     app, client, session, jwt, mock_redis_client
 ):
+    """Testing POST /form/form-flow-builder with only title in formData."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1239,6 +1243,7 @@ def test_form_flow_builder_post_with_title_only_validation(
 def test_form_flow_builder_post_with_path_only_validation(
     app, client, session, jwt, mock_redis_client
 ):
+    """Testing POST /form/form-flow-builder with only path in formData."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1261,6 +1266,7 @@ def test_form_flow_builder_post_with_path_only_validation(
 def test_form_flow_builder_post_without_title_path_no_validation(
     app, client, session, jwt, mock_redis_client
 ):
+    """Testing POST /form/form-flow-builder without title/path - should skip validation."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1277,6 +1283,7 @@ def test_form_flow_builder_post_without_title_path_no_validation(
 def test_form_flow_builder_put_with_query_params_validation_success(
     app, client, session, jwt, mock_redis_client, create_mapper
 ):
+    """Testing PUT /form/form-flow-builder/<mapper_id> with title/path query params - success."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1305,6 +1312,7 @@ def test_form_flow_builder_put_with_query_params_validation_success(
 def test_form_flow_builder_put_with_query_params_validation_failure(
     app, client, session, jwt, mock_redis_client, create_mapper
 ):
+    """Testing PUT /form/form-flow-builder/<mapper_id> with title/path query params - failure."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1333,6 +1341,7 @@ def test_form_flow_builder_put_with_query_params_validation_failure(
 def test_form_flow_builder_put_without_query_params_no_validation(
     app, client, session, jwt, mock_redis_client, create_mapper
 ):
+    """Testing PUT /form/form-flow-builder/<mapper_id> without query params - should skip validation."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1357,6 +1366,7 @@ def test_form_flow_builder_put_without_query_params_no_validation(
 def test_form_flow_builder_post_validation_invalid_title_format(
     app, client, session, jwt, mock_redis_client
 ):
+    """Testing POST /form/form-flow-builder with invalid title format."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 
@@ -1376,6 +1386,7 @@ def test_form_flow_builder_post_validation_invalid_title_format(
 def test_form_flow_builder_post_validation_invalid_path_format(
     app, client, session, jwt, mock_redis_client
 ):
+    """Testing POST /form/form-flow-builder with invalid path format."""
     token = get_token(jwt, role=CREATE_DESIGNS, username="designer")
     headers = {"Authorization": f"Bearer {token}", "content-type": "application/json"}
 

--- a/forms-flow-api/tests/unit/api/test_form_process_mapper.py
+++ b/forms-flow-api/tests/unit/api/test_form_process_mapper.py
@@ -293,13 +293,17 @@ def test_form_flow_builder_creation(app, client, session, jwt, mock_redis_client
         "taskVariables": task_variables
     }
 
-    response = client.post("/form/form-flow-builder", headers=headers, json=payload)
-    assert response.status_code == 201
-    assert response.json.get("formData") is not None
-    assert response.json["formData"].get("title") == form_data.get("title")
-    assert response.json.get("process") is not None
-    assert response.json.get("mapper") is not None
-    assert response.json.get("authorizations") is not None
+    with patch(
+        "formsflow_api_utils.services.external.formio.FormioService.get_form_search",
+        return_value=[],
+    ):
+        response = client.post("/form/form-flow-builder", headers=headers, json=payload)
+        assert response.status_code == 201
+        assert response.json.get("formData") is not None
+        assert response.json["formData"].get("title") == form_data.get("title")
+        assert response.json.get("process") is not None
+        assert response.json.get("mapper") is not None
+        assert response.json.get("authorizations") is not None
 
 
 def test_form_flow_builder_minimal(app, client, session, jwt, mock_redis_client):
@@ -312,8 +316,12 @@ def test_form_flow_builder_minimal(app, client, session, jwt, mock_redis_client)
         "formData": form_data
     }
 
-    response = client.post("/form/form-flow-builder", headers=headers, json=payload)
-    assert response.status_code == 201
+    with patch(
+        "formsflow_api_utils.services.external.formio.FormioService.get_form_search",
+        return_value=[],
+    ):
+        response = client.post("/form/form-flow-builder", headers=headers, json=payload)
+        assert response.status_code == 201
     assert response.json.get("formData") is not None
     assert response.json["formData"].get("title") == form_data.get("title")
     assert response.json.get("process") is not None
@@ -1042,13 +1050,17 @@ def test_form_flow_builder_update(app, client, session, jwt, mock_redis_client):
     payload = {
         "formData": form_data
     }
-    response = client.post("/form/form-flow-builder", headers=headers, json=payload)
-    assert response.status_code == 201
-    assert response.json is not None
-    assert response.json.get("formData") is not None
-    form_id = response.json["formData"].get("_id")
-    mapper_id = response.json.get("mapper").get("id")
-    process_id = response.json.get("process").get("id")
+    with patch(
+        "formsflow_api_utils.services.external.formio.FormioService.get_form_search",
+        return_value=[],
+    ):
+        response = client.post("/form/form-flow-builder", headers=headers, json=payload)
+        assert response.status_code == 201
+        assert response.json is not None
+        assert response.json.get("formData") is not None
+        form_id = response.json["formData"].get("_id")
+        mapper_id = response.json.get("mapper").get("id")
+        process_id = response.json.get("process").get("id")
     ensure_process_data_binary(process_id)
     # Ensure no pending dirty state before the next request (avoid autoflush issues)
     session.commit()
@@ -1173,8 +1185,12 @@ def test_form_flow_builder_post_with_title_path_validation_success(
 
     payload = {"formData": form_data}
 
-    response = client.post("/form/form-flow-builder", headers=headers, json=payload)
-    assert response.status_code == 201
+    with patch(
+        "formsflow_api_utils.services.external.formio.FormioService.get_form_search",
+        return_value=[],
+    ):
+        response = client.post("/form/form-flow-builder", headers=headers, json=payload)
+        assert response.status_code == 201
 
 
 def test_form_flow_builder_post_with_title_path_validation_failure(
@@ -1212,8 +1228,12 @@ def test_form_flow_builder_post_with_title_only_validation(
 
     payload = {"formData": form_data}
 
-    response = client.post("/form/form-flow-builder", headers=headers, json=payload)
-    assert response.status_code == 201
+    with patch(
+        "formsflow_api_utils.services.external.formio.FormioService.get_form_search",
+        return_value=[],
+    ):
+        response = client.post("/form/form-flow-builder", headers=headers, json=payload)
+        assert response.status_code == 201
 
 
 def test_form_flow_builder_post_with_path_only_validation(
@@ -1230,8 +1250,12 @@ def test_form_flow_builder_post_with_path_only_validation(
 
     payload = {"formData": form_data}
 
-    response = client.post("/form/form-flow-builder", headers=headers, json=payload)
-    assert response.status_code == 201
+    with patch(
+        "formsflow_api_utils.services.external.formio.FormioService.get_form_search",
+        return_value=[],
+    ):
+        response = client.post("/form/form-flow-builder", headers=headers, json=payload)
+        assert response.status_code == 201
 
 
 def test_form_flow_builder_post_without_title_path_no_validation(
@@ -1242,8 +1266,12 @@ def test_form_flow_builder_post_without_title_path_no_validation(
 
     payload = {"formData": get_formio_form_request_payload()}
 
-    response = client.post("/form/form-flow-builder", headers=headers, json=payload)
-    assert response.status_code == 201
+    with patch(
+        "formsflow_api_utils.services.external.formio.FormioService.get_form_search",
+        return_value=[],
+    ):
+        response = client.post("/form/form-flow-builder", headers=headers, json=payload)
+        assert response.status_code == 201
 
 
 def test_form_flow_builder_put_with_query_params_validation_success(
@@ -1262,12 +1290,16 @@ def test_form_flow_builder_put_with_query_params_validation_success(
         }
     }
 
-    response = client.put(
-        f"/form/form-flow-builder/{mapper_id}?title=UpdatedTitle&path=updatedPath",
-        headers=headers,
-        json=payload,
-    )
-    assert response.status_code == 200
+    with patch(
+        "formsflow_api_utils.services.external.formio.FormioService.get_form_search",
+        return_value=[],
+    ):
+        response = client.put(
+            f"/form/form-flow-builder/{mapper_id}?title=UpdatedTitle&path=updatedPath",
+            headers=headers,
+            json=payload,
+        )
+        assert response.status_code == 200
 
 
 def test_form_flow_builder_put_with_query_params_validation_failure(

--- a/forms-flow-api/tests/unit/api/test_user.py
+++ b/forms-flow-api/tests/unit/api/test_user.py
@@ -102,7 +102,7 @@ class TestUserLoginDetails:
 
     def test_get_user_login_details_success(self, app, client, session, jwt):
         """Test successful retrieval of user login details."""
-        token = get_token(jwt, username="formsflow-reviewer")
+        token = get_token(jwt, username="formsflow-reviewer", role=VIEW_TASKS)
         headers = {
             "Authorization": f"Bearer {token}",
             "content-type": "application/json",
@@ -137,7 +137,7 @@ class TestUserLoginDetails:
 
     def test_get_user_login_details_internal_user(self, app, client, session, jwt):
         """Test login details for a user with internal (local) authentication."""
-        token = get_token(jwt, username="formsflow-reviewer")
+        token = get_token(jwt, username="formsflow-reviewer", role=VIEW_TASKS)
         headers = {
             "Authorization": f"Bearer {token}",
             "content-type": "application/json",


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
included validate API in builder API

**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-5689

**DEPENDENCY PR:**  
<!-- Dependency Ticket link like this format - https://github.com/AOT-Technologies/forms-flow-ai/pull/3012 -->

**Type of Change:**
- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 🔄 SYNC PR (for syncing different repos)
- [ ] 📦 Dependency / Package Updates
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config Change / Yaml changes

---

## 💻 Frontend Changes 

**Modules/Components Affected:**
<!-- List key components, pages, or hooks modified. -->

**Summary of Frontend Changes:**
<!-- Describe UI/UX or logic updates. -->

**UI/UX Review:**
- [ ] Required
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**



---

## ⚙️ Backend Changes (Java / Python)

**Modules/Endpoints Affected:**
/form-flow-builder
/form-flow-builder/<int:mapper_id>

**Summary of Backend Changes:**
included validate API in builder API

**API Testing:**
- [x] Done
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<img width="1671" height="661" alt="Screenshot 2026-01-28 130400" src="https://github.com/user-attachments/assets/029c7c66-2fb2-4964-a1ca-bac26103ec57" />

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [x] Unit tests added or updated [Backend]
- [ ] UI verified [Frontend]   
- [ ] Documentation updated (README / Confluence / API Docs)  
- [x] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description as per standard format**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  



**Details:**
<!-- Add additional details if any of the above boxes are checked.[optional] -->

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers. -->


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Add `title` and `path` query validation in builder endpoints

- Invoke `validate_form_name_path_title` before create/update

- Expand unit tests for validation success and failure

- Update user login tests with `VIEW_TASKS` role


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Req["Client Request"] -- "POST/PUT with title/path" --> Extract["Extract title/path"]
  Extract -- "present?" --> Check{"title or path provided?"}
  Check -- "yes" --> Validate["validate_form_name_path_title"]
  Check -- "no" --> Skip["Skip validation"]
  Validate --> Process["create/update form process"]
  Skip --> Process
  Process --> Res["Return response"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>form_process_mapper.py</strong><dd><code>Add title/path query validation to builder API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/src/formsflow_api/resources/form_process_mapper.py

<ul><li>Add <code>title</code> and <code>path</code> params to <code>@API.doc</code><br> <li> Extract <code>title</code> and <code>path</code> from <code>request.args</code><br> <li> Call <code>validate_form_name_path_title</code> when provided<br> <li> Mirror changes for both POST and PUT endpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3151/files#diff-03ec1738e9745151123e5c3c2daa8f4b1d590f4e47694dc8ea53f280c6310e7a">+42/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_form_process_mapper.py</strong><dd><code>Extend builder API tests for validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/tests/unit/api/test_form_process_mapper.py

<ul><li>Wrap builder POST calls with FormioService.get_form_search patch<br> <li> Add tests for title/path validation success and duplicate cases<br> <li> Cover title-only, path-only, and no-validation scenarios<br> <li> Add invalid title and path format tests</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3151/files#diff-316bb9879e42371cfeb03bee32945f5f3b5347125c9cff2c10e9c8136e18e783">+264/-16</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_user.py</strong><dd><code>Add role parameter to user login tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-api/tests/unit/api/test_user.py

- Include `role=VIEW_TASKS` in `get_token` calls


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3151/files#diff-cd5b4c9093ae023b29c55d15525fcd0cea675e201cd2d5e7887c59ec21f6e4ac">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

