### PR TITLE
FWF-6046 [FEATURE]-Replaced Table Empty State

### DIFF
--- a/forms-flow-web/src/components/Form/constants/FormTable.js
+++ b/forms-flow-web/src/components/Form/constants/FormTable.js
@@ -436,7 +436,7 @@ const handlePageChange = (page) => {
         onClick: () => navigateToDesignFormBuild(dispatch, tenantKey),
         variant: "primary",
         size: "medium",
-        dataTestId: "clear-filters-button"
+        dataTestId: "create-new-form-button"
       }}
     />
     <PromptModal

--- a/forms-flow-web/src/components/Form/constants/FormTable.js
+++ b/forms-flow-web/src/components/Form/constants/FormTable.js
@@ -16,6 +16,7 @@ import { manipulatingFormData } from "../../../apiManager/services/formFormatter
 import _cloneDeep from "lodash/cloneDeep";
 import { toast } from "react-toastify";
 import PropTypes from "prop-types";
+import { navigateToDesignFormBuild } from "../../../helper/routerHelper.js";
 
 function FormTable({
   isDuplicating,
@@ -429,6 +430,14 @@ const handlePageChange = (page) => {
       onPaginationModelChange={externalOnPaginationModelChange || onPaginationModelChange}
       getRowId={(row) => row.id}
       autoHeight={true}
+      emptyStateMessage="No forms found"
+      emptyStateAction={{
+        label: t("Create new form"),
+        onClick: () => navigateToDesignFormBuild(dispatch, tenantKey),
+        variant: "primary",
+        size: "medium",
+        dataTestId: "clear-filters-button"
+      }}
     />
     <PromptModal
         show={showDeleteModal}

--- a/forms-flow-web/src/components/Form/constants/SubmissionsAndDraftTable.js
+++ b/forms-flow-web/src/components/Form/constants/SubmissionsAndDraftTable.js
@@ -11,7 +11,7 @@ import { useTranslation } from "react-i18next";
 import { PromptModal, V8CustomButton, ReusableTable } from "@formsflow/components";
 import { toast } from "react-toastify";
 import { deleteDraftbyId } from "../../../apiManager/services/draftService";
-import { navigateToDraftEdit, navigateToViewSubmission, navigateToResubmit } from "../../../helper/routerHelper";
+import { navigateToDraftEdit, navigateToViewSubmission, navigateToResubmit, navigateToNewSubmission } from "../../../helper/routerHelper";
 import PropTypes from "prop-types";
 import { HelperServices } from "@formsflow/service";
 
@@ -36,6 +36,9 @@ const SubmissionsAndDraftTable = ({ fetchSubmissionsAndDrafts }) => {
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [deleteDraftId, setDeleteDraftId] = useState('');
     const [isDeletionLoading, setIsDeletionLoading] = useState(false);
+    const formId = useSelector(
+      (state) => state.applications.draftAndSubmissionsList?.formId
+    );
 
   const gridFieldToSortKey = {
     id: "id",
@@ -296,7 +299,14 @@ const SubmissionsAndDraftTable = ({ fetchSubmissionsAndDrafts }) => {
         paginationModel={paginationModel}
         onPaginationModelChange={onPaginationModelChange}
         getRowId={(row) => row.id}
-        noRowsLabel={t("No Entries have been found.")}
+        emptyStateMessage="No submissions found"
+        emptyStateAction={{
+          label: t("Create new submission"),
+          onClick: () => navigateToNewSubmission(dispatch, tenantKey, formId),
+          variant: "primary",
+          size: "medium",
+          dataTestId: "create-new-submission-button"
+        }}
         autoHeight={true}
         dataGridProps={{
           sx: {


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
Replace generic table empty states

**Related Jira Ticket:**  
[https://aottech.atlassian.net/browse/FWF-6046](https://aottech.atlassian.net/browse/FWF-6046)

**DEPENDENCY PR:**  
None

**Type of Change:**
- [x] ✨ Feature
- [ ] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 🔄 SYNC PR (for syncing different repos)
- [ ] 📦 Dependency / Package Updates
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config Change / Yaml changes

---

## 💻 Frontend Changes 

**Modules/Components Affected:**
- forms-flow-web/src/components/Form/constants/FormTable.js
- forms-flow-web/src/components/Form/constants/SubmissionsAndDraftTable.js

**Summary of Frontend Changes:**
Replaced generic table empty messages

**UI/UX Review:**
- [x] Required
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings for UI changes. -->

---

## ⚙️ Backend Changes (Java / Python)

**Modules/Endpoints Affected:**
<!-- List controllers, services, or APIs modified. -->

**Summary of Backend Changes:**
<!-- Describe logic changes, data model updates, or new APIs added. -->

**API Testing:**
- [ ] Done
- [ ] Not Applicable

**Screenshots / Screen Recordings (if applicable):**
<!-- Attach before/after screenshots or screen recordings . -->

## ✅ Checklist

- [x] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated [Backend]
- [x] UI verified [Frontend]   
- [ ] Documentation updated (README / Confluence / API Docs)  
- [x] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description as per standard format**  
- [x] I have verified **cross-repo dependencies** (if any)  
- [x] I have confirmed **backward compatibility** with previous releases  



**Details:**
<!-- Add additional details if any of the above boxes are checked.[optional] -->

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers. -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add actionable empty states to tables

- Provide "Create" CTA navigation handlers

- Update table test IDs for CTAs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  formTable["`FormTable` empty state + create form CTA"]
  submissionsTable["`SubmissionsAndDraftTable` empty state + create submission CTA"]
  routerHelper["`routerHelper` navigation functions"]
  designForm["Form builder route"]
  newSubmission["New submission flow"]

  formTable -- "uses" --> routerHelper
  submissionsTable -- "uses" --> routerHelper
  routerHelper -- "navigates to" --> designForm
  routerHelper -- "navigates to" --> newSubmission
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormTable.js</strong><dd><code>Add empty-state CTA to forms table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/constants/FormTable.js

<ul><li>Import <code>navigateToDesignFormBuild</code> navigation helper<br> <li> Add <code>emptyStateMessage</code> for empty forms list<br> <li> Add <code>emptyStateAction</code> to create new form<br> <li> Provide CTA <code>dataTestId</code> for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3175/files#diff-b74eebc5e24b825c00b858b2a650cde1538951dbeb5e645e680e573495c1b00a">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SubmissionsAndDraftTable.js</strong><dd><code>Add empty-state CTA to submissions table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-web/src/components/Form/constants/SubmissionsAndDraftTable.js

<ul><li>Import <code>navigateToNewSubmission</code> navigation helper<br> <li> Read <code>formId</code> from <code>draftAndSubmissionsList</code> state<br> <li> Replace <code>noRowsLabel</code> with <code>emptyStateMessage</code> and CTA<br> <li> Add CTA <code>dataTestId</code> for testing</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3175/files#diff-96a8076e8c62f285624cb3a4caebb5c00e21f16f1dd2e6ab5d4b679d86b795ae">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

