### PR TITLE
Security Hardening for Trivy Scan Workflow

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - develop
-
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  security-events: write   # needed for upload-sarif
+  contents: read
+  actions: read
 
 jobs:
   repo-scan:
@@ -15,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -27,7 +29,7 @@ jobs:
           severity: 'HIGH,CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -44,8 +46,10 @@ jobs:
           - { name: "redash", tag: "24.04.0" }
           - { name: "forms-flow-data-analysis-api", tag: "latest" }
           - { name: "forms-flow-documents-api", tag: "latest" }
-
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Authenticate with Docker Hub
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -53,14 +57,15 @@ jobs:
         run: |
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
-      - name: Install Trivy
+      - name: Install Trivy (pinned to last known clean version)
         run: |
           sudo apt-get update
           sudo apt-get install -y wget apt-transport-https gnupg
           wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
           echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -cs) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
           sudo apt-get update
-          sudo apt-get install -y trivy
+          # Pinned to v0.69.3 — last known clean version before the compromise
+          sudo apt-get install -y trivy=0.69.3
 
       - name: Download Trivy HTML Template
         run: wget https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/html.tpl -O html.tpl
@@ -78,7 +83,7 @@ jobs:
           docker.io/formsflow/${{ matrix.service.name }}:${{ matrix.service.tag }}
 
       - name: Upload Trivy Image Scan Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: trivy-${{ matrix.service.name }}-results
           path: trivy-${{ matrix.service.name }}-results.html

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -27,6 +27,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
+          trivy-version: 'v0.69.3
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
- Pin actions to immutable commit SHAs to prevent supply chain attacks
- Restrict GITHUB_TOKEN permissions to least privilege (read contents, write security-events)
- Pin Trivy binary version to 0.35.0 (last known clean version)
- Audited other third-party actions in the repository

**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/OPS-293

**Type of Change:**
- [ ] 🐞 Bug Fix


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Restrict workflow token permissions

- Pin GitHub Actions to SHAs

- Pin Trivy versions for safer scans

- Add checkout to image scan job


___

### Diagram Walkthrough


```mermaid
flowchart LR
  wf["Trivy scan workflow"]
  perms["Least-privilege permissions"]
  actions["Pinned action commit SHAs"]
  trivy["Pinned Trivy scanner versions"]
  checkout["Checkout in image scan job"]
  wf -- "restricts" --> perms
  wf -- "locks" --> actions
  wf -- "stabilizes" --> trivy
  wf -- "adds" --> checkout
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>trivy-scan.yml</strong><dd><code>Secure and stabilize Trivy workflow execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/trivy-scan.yml

<ul><li>Replaced broad <code>write-all</code> permissions with scoped <code>security-events</code>, <br><code>contents</code>, and <code>actions</code> access.<br> <li> Pinned <code>actions/checkout</code>, <code>aquasecurity/trivy-action</code>, <br><code>github/codeql-action/upload-sarif</code>, and <code>actions/upload-artifact</code> to <br>commit SHAs.<br> <li> Added a <code>Checkout</code> step to the <code>image-scans</code> job before scanning <br>artifacts.<br> <li> Pinned installed Trivy CLI to <code>0.69.3</code> and clarified version intent in <br>the install step name/comment.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3222/files#diff-d2f2b520bb7bfb36f97c6ec62a237288585d8f9d4301d9b31cb0c3dfad98f1c9">+14/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

