### PR TITLE
remove outdated setup instructions from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ Unlike "black box" proprietary vendors, formsflow.ai is built on a transparent f
 
 ### formsflow.ai Setup
 
-[Instructions for the setup](/deployment/Individual-deployment/README.md)
-
 Check out the [installation documentation](https://aot-technologies.github.io/forms-flow-installation-eks/docs/windows) for installation instructions and [features documentation](https://aot-technologies.github.io/forms-flow-ai-doc) to explore features and capabilities in detail.
 
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Remove outdated setup link

- Keep current installation documentation reference


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Remove outdated README setup link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Removed the outdated <code>/deployment/Individual-deployment/README.md</code> setup <br>instructions link.<br> <li> Left the current installation and features documentation links intact.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai/pull/3309/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

